### PR TITLE
Dev 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,59 @@ True
  Token(form='누구', tag='NP', start=5, len=2),
  Token(form='야', tag='JKV', start=7, len=1)]
 
+# v0.11.0 신기능
+# 변형된 형태소를 일괄적으로 추가하여 대상 텍스트에 맞춰 분석 성능을 높일 수 있습니다.
+>>> kiwi = Kiwi()
+>>> kiwi.tokenize("안녕하세영, 제 이름은 이세영이에영. 학생이세영?")
+[Token(form='안녕', tag='NNG', start=0, len=2),
+ Token(form='하', tag='XSA', start=2, len=1),
+ Token(form='시', tag='EP', start=3, len=1),
+ Token(form='어', tag='EC', start=3, len=1),
+ Token(form='영', tag='MAG', start=4, len=1), # 오분석
+ Token(form=',', tag='SP', start=5, len=1),
+ Token(form='저', tag='NP', start=7, len=1),
+ Token(form='의', tag='JKG', start=7, len=1),
+ Token(form='이름', tag='NNG', start=9, len=2),
+ Token(form='은', tag='JX', start=11, len=1),
+ Token(form='이세영', tag='NNP', start=13, len=3),
+ Token(form='이', tag='JKS', start=16, len=1),
+ Token(form='에', tag='IC', start=17, len=1),
+ Token(form='영', tag='NR', start=18, len=1),
+ Token(form='.', tag='SF', start=19, len=1),
+ Token(form='님', tag='NNG', start=21, len=1),
+ Token(form='도', tag='JX', start=22, len=1),
+ Token(form='학생', tag='NNG', start=24, len=2),
+ Token(form='이세영', tag='NNP', start=26, len=3), # 오분석
+ Token(form='?', tag='SF', start=29, len=1)]
+
+# 종결어미(EF) 중 '요'로 끝나는 것들을 '영'으로 대체하여 일괄 삽입합니다. 
+# 이 때 변형된 종결어미에는 -3의 페널티를 부여하여 원 형태소보다 우선하지 않도록 합니다.
+# 새로 삽입된 형태소들이 반환됩니다.
+>>> kiwi.add_re_rule('EF', '요$', '영', -3)
+['어영', '에영', '지영', '잖아영', '거든영', 'ᆯ까영', '네영', '구영', '나영', '군영', ..., '으니깐영']
+
+# 동일한 문장을 재분석하면 분석 결과가 개선된 것을 확인할 수 있습니다.
+>>> kiwi.tokenize("안녕하세영, 제 이름은 이세영이에영. 님도 학생이세영?")
+[Token(form='안녕', tag='NNG', start=0, len=2),
+ Token(form='하', tag='XSA', start=2, len=1),
+ Token(form='시', tag='EP', start=3, len=1),
+ Token(form='어영', tag='EF', start=3, len=2), # 분석 결과 개선
+ Token(form=',', tag='SP', start=5, len=1),
+ Token(form='저', tag='NP', start=7, len=1),
+ Token(form='의', tag='JKG', start=7, len=1),
+ Token(form='이름', tag='NNG', start=9, len=2),
+ Token(form='은', tag='JX', start=11, len=1),
+ Token(form='이세영', tag='NNP', start=13, len=3),
+ Token(form='이', tag='VCP', start=16, len=1),
+ Token(form='에영', tag='EF', start=17, len=2),
+ Token(form='.', tag='SF', start=19, len=1),
+ Token(form='님', tag='NNG', start=21, len=1),
+ Token(form='도', tag='JX', start=22, len=1),
+ Token(form='학생', tag='NNG', start=24, len=2),
+ Token(form='이', tag='VCP', start=26, len=1),
+ Token(form='시', tag='EP', start=27, len=1),
+ Token(form='어영', tag='EF', start=27, len=2), # 분석 결과 개선
+ Token(form='?', tag='SF', start=29, len=1)]
 ```
 
 ## 시작하기

--- a/document/document_header.html
+++ b/document/document_header.html
@@ -10,8 +10,10 @@
 <a class="homelink" rel="home" title="kiwipiepy Home" href="/kiwipiepy" style="display:block; font-size:2em; font-weight:bold; color:#555; padding-bottom:.5em; border-bottom:1px solid silver;"> <img src="/kiwipiepy/logo.png" alt="" style="height:1.5em;"> kiwipiepy </a>
 <!--a id='lang-en' href="../en/index.html">English</a--> <a id='lang-kr' href="../kr/index.html">한국어</a> 
 <div id="version-link">
-<span>v0.10.2</span>
+<span>v0.11.0</span>
 <ul>
+    <li><a href='/kiwipiepy/v0.11.0/kr'>v0.11.0</a></li>
+    <li><a href='/kiwipiepy/v0.10.3/kr'>v0.10.3</a></li>
     <li><a href='/kiwipiepy/v0.10.2/kr'>v0.10.2</a></li>
     <li><a href='/kiwipiepy/v0.10.1/kr'>v0.10.1</a></li>
     <li><a href='/kiwipiepy/v0.10.0/kr'>v0.10.0</a></li>

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -176,7 +176,7 @@ Returns
 inserted: bool
     사용자 정의 형태소가 정상적으로 삽입된 경우 True, 이미 동일한 형태소가 존재하여 삽입되지 않은 경우 False를 반환합니다.
         '''
-
+        if re.search(r'\s', word): raise ValueError("Whitespace characters are not allowed at `word`")
         return super().add_user_word(word, tag, score, orig_word)
     
     def add_pre_analyzed_word(self,

--- a/kiwipiepy/documentation.rst
+++ b/kiwipiepy/documentation.rst
@@ -395,6 +395,16 @@ Python 모듈 관련 오류는  https://github.com/bab2min/kiwipiepy/issues, 형
 
 역사
 ----
+* 0.11.0 (2022-03-19)
+    * Kiwi 0.11.0의 기능들(https://github.com/bab2min/Kiwi/releases/tag/v0.11.0 )이 반영되었습니다.
+        * 이용자 사전을 관리하는 메소드 `Kiwi.add_pre_analyzed_word`, `Kiwi.add_rule`, `Kiwi.add_re_rule`가 추가되었습니다.
+        * 분석 시 접두사/접미사 및 동/형용사 전성어미의 분리여부를 선택할 수 있는 옵션 `Match.JOIN_NOUN_PREFIX`, `Match.JOIN_NOUN_SUFFIX`, `Match.JOIN_VERB_SUFFIX`, `Match.JOIN_ADJ_SUFFIX`가 추가되었습니다.
+        * 결합된 형태소 `Token`의 `start`, `end`, `length`가 부정확한 버그를 수정했습니다.
+        * 이제 형태소 결합 규칙이 Kiwi 모델 내로 통합되어 `Kiwi.add_user_word`로 추가된 동/형용사의 활용형도 정상적으로 분석이 됩니다.
+        * 언어 모델의 압축 알고리즘을 개선하여 초기 로딩 속도를 높였습니다.
+        * SIMD 최적화가 개선되었습니다.
+        * 언어 모델 및 기본 사전을 업데이트하여 전반적인 정확도를 높였습니다.
+
 * 0.10.3 (2021-12-22)
     * Kiwi 0.10.3의 기능들(https://github.com/bab2min/Kiwi/releases/tag/v0.10.3 )이 반영되었습니다.
         * `Token`에 `sent_position`, `line_number` 프로퍼티가 추가되었습니다.

--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -99,6 +99,36 @@ struct KiwiObject : py::CObject<KiwiObject>
 		kiwi.setCutOffThreshold(v);
 	}
 
+	size_t getMaxUnkFormSize() const
+	{
+		return kiwi.getMaxUnkFormSize();
+	}
+
+	void setMaxUnkFormSize(size_t v)
+	{
+		kiwi.setMaxUnkFormSize(v);
+	}
+
+	float getUnkScoreBias() const
+	{
+		return kiwi.getUnkScoreBias();
+	}
+
+	void setUnkScoreBias(float v)
+	{
+		kiwi.setUnkScoreBias(v);
+	}
+
+	float getUnkScoreScale() const
+	{
+		return kiwi.getUnkScoreScale();
+	}
+
+	void setUnkScoreScale(float v)
+	{
+		kiwi.setUnkScoreScale(v);
+	}
+
 	bool getIntegrateAllomorph() const
 	{
 		return kiwi.getIntegrateAllomorph();
@@ -134,6 +164,9 @@ py::TypeWrapper<KiwiObject> _KiwiSetter{ [](PyTypeObject& obj)
 	{
 		{ (char*)"_cutoff_threshold", PY_GETTER_MEMFN(&KiwiObject::getCutOffThreshold), PY_SETTER_MEMFN(&KiwiObject::setCutOffThreshold), "", nullptr },
 		{ (char*)"_integrate_allomorph", PY_GETTER_MEMFN(&KiwiObject::getIntegrateAllomorph), PY_SETTER_MEMFN(&KiwiObject::setIntegrateAllomorph), "", nullptr },
+		{ (char*)"_unk_score_bias", PY_GETTER_MEMFN(&KiwiObject::getUnkScoreBias), PY_SETTER_MEMFN(&KiwiObject::setUnkScoreBias), "", nullptr },
+		{ (char*)"_unk_score_scale", PY_GETTER_MEMFN(&KiwiObject::getUnkScoreScale), PY_SETTER_MEMFN(&KiwiObject::setUnkScoreScale), "", nullptr },
+		{ (char*)"_max_unk_form_size", PY_GETTER_MEMFN(&KiwiObject::getMaxUnkFormSize), PY_SETTER_MEMFN(&KiwiObject::setMaxUnkFormSize), "", nullptr },
 		{ (char*)"_num_workers", PY_GETTER_MEMFN(&KiwiObject::getNumWorkers), nullptr, "", nullptr },
 		{ nullptr },
 	};


### PR DESCRIPTION
* 이용자 사전을 관리하는 메소드 `Kiwi.add_pre_analyzed_word`, `Kiwi.add_rule`, `Kiwi.add_re_rule`가 추가되었습니다.
* 분석 시 접두사/접미사 및 동/형용사 전성어미의 분리여부를 선택할 수 있는 옵션 `Match.JOIN_NOUN_PREFIX`, `Match.JOIN_NOUN_SUFFIX`, `Match.JOIN_VERB_SUFFIX`, `Match.JOIN_ADJ_SUFFIX`가 추가되었습니다.
* 결합된 형태소 `Token`의 `start`, `end`, `length`가 부정확한 버그를 수정했습니다.
* 이제 형태소 결합 규칙이 Kiwi 모델 내로 통합되어 `Kiwi.add_user_word`로 추가된 동/형용사의 활용형도 정상적으로 분석이 됩니다.
* 언어 모델의 압축 알고리즘을 개선하여 초기 로딩 속도를 높였습니다.
* SIMD 최적화가 개선되었습니다.
* 언어 모델 및 기본 사전을 업데이트하여 전반적인 정확도를 높였습니다.