### PR TITLE
Fixing wrong spacing in joining tokens

### DIFF
--- a/kiwipiepy/_c_api.pyi
+++ b/kiwipiepy/_c_api.pyi
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union, Optional, Tuple
 
 class Token:
     '''
@@ -83,6 +83,13 @@ class Token:
         '''.. versionadded:: 0.11.1
 
 form과 tag를 `형태/품사태그`꼴로 합쳐서 반환합니다.'''
+        ...
+
+    @property
+    def form_tag(self) -> Tuple[str, str]:
+        '''.. versionadded:: 0.15.2
+
+(form, tag)를 반환합니다.'''
         ...
 
     @property

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -1487,10 +1487,10 @@ Notes
 
 Parameters
 ----------
-morphs: Iterable[Union[Token, Tuple[str, str]]]
+morphs: Iterable[Union[Token, Tuple[str, str], Tuple[str, str, bool]]]
     결합할 형태소의 목록입니다. 
     각 형태소는 `Kiwi.tokenize`에서 얻어진 `Token` 타입이거나, 
-    (형태, 품사)로 구성된 `tuple` 타입이어야 합니다.
+    (형태, 품사) 혹은 (형태, 품사, 왼쪽 띄어쓰기 유무)로 구성된 `tuple` 타입이어야 합니다.
 lm_search: bool
     둘 이상의 형태로 복원 가능한 모호한 형태소가 있는 경우, 이 값이 True면 언어 모델 탐색을 통해 최적의 형태소를 선택합니다.
     False일 경우 탐색을 실시하지 않지만 더 빠른 속도로 복원이 가능합니다.
@@ -1536,6 +1536,13 @@ Token(form='결과', tag='NNG', start=4, len=2)
 '묻어요'
 >> kiwi.join([('묻', 'VV-I'), ('어요', 'EF')])
 '물어요'
+
+# 0.15.2버전부터는 Tuple의 세번째 요소로 띄어쓰기 유무를 지정할 수 있습니다. 
+# True일 경우 강제로 띄어쓰기, False일 경우 강제로 붙여쓰기를 수행합니다.
+>> kiwi.join([('길', 'NNG'), ('을', 'JKO', True), ('묻', 'VV'), ('어요', 'EF')])
+'길 을 물어요'
+>> kiwi.join([('길', 'NNG'), ('을', 'JKO'), ('묻', 'VV', False), ('어요', 'EF')])
+'길을물어요'
 
 # 과거형 선어말어미를 제거하는 예시
 >> remove_past = lambda s: kiwi.join(t for t in kiwi.tokenize(s) if t.tagged_form != '었/EP')

--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -1,4 +1,4 @@
-#define _SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING
+﻿#define _SILENCE_CXX17_RESULT_OF_DEPRECATION_WARNING
 
 #include <stdexcept>
 #include <fstream>
@@ -564,6 +564,11 @@ struct TokenObject : py::CObject<TokenObject>
 		ret.insert(ret.end(), _tag, _tag + strlen(_tag));
 	 	return ret;
 	}
+	
+	py::UniqueObj formTag() const
+	{
+		return py::buildPyTuple(_form, _tag);
+	}
 
 	u16string baseForm() const
 	{
@@ -639,6 +644,7 @@ py::TypeWrapper<TokenObject> _TokenSetter{ gModule, [](PyTypeObject& obj)
 		{ (char*)"base_form", PY_GETTER_MEMFN(&TokenObject::baseForm), nullptr, "", nullptr},
 		{ (char*)"base_id", PY_GETTER_MEMFN(&TokenObject::baseId), nullptr, "", nullptr},
 		{ (char*)"tagged_form", PY_GETTER_MEMFN(&TokenObject::taggedForm), nullptr, "", nullptr},
+		{ (char*)"form_tag", PY_GETTER_MEMFN(&TokenObject::formTag), nullptr, "", nullptr},
 		{ (char*)"score", PY_GETTER_MEMPTR(&TokenObject::_score), nullptr, "", nullptr},
 		{ (char*)"typo_cost", PY_GETTER_MEMPTR(&TokenObject::_typoCost), nullptr, "", nullptr},
 		{ (char*)"raw_form", PY_GETTER_MEMPTR(&TokenObject::_raw_form), nullptr, "", nullptr},

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -410,6 +410,25 @@ def test_join():
         == "왜 저한테 물어요"
     )
 
+    assert (kiwi.join([("왜", "MAG"), ("저", "NP"), ("한테", "JKB", True), ("묻", "VV-I"), ("어요", "EF")])
+        == "왜 저 한테 물어요"
+    )
+
+    assert (kiwi.join([("왜", "MAG"), ("저", "NP"), ("한테", "JKB"), ("묻", "VV-I", False), ("어요", "EF")])
+        == "왜 저한테물어요"
+    )
+
+def test_join_edge_cases():
+    kiwi = Kiwi()
+    for c in [
+        '가격이 싼 것이 이것뿐이에요.'
+    ]:
+        tokens = kiwi.tokenize(c)
+        restored = kiwi.join(tokens)
+        raw = kiwi.join([(t.form, t.tag) for t in tokens])
+        assert c == restored
+        assert c == raw
+
 def test_bug_87():
     text = "한글(韓㐎[1], 영어: Hangeul[2]또는 Hangul[3])은 한국어의 공식문자로서, 세종이 한국어를 표기하기 위하여 창제한 문자인 '훈민정음'(訓民正音)을 20세기 초반 이후 달리 이르는 명칭이다.[4][5] 한글이란 이름은 주시경 선생과 국어연구학회 회원들에 의해 지어진것으로 알려져 있으며[6][7][8][9] 그 뜻은 '으뜸이 되는 큰글', '오직 하나뿐인 큰글', '한국인의 글자'이다.[6][10] 한글의 또 다른 별칭으로는 정음(正音), 언문(諺文)[11], 언서(諺書), 반절(反切), 암클, 아햇글, 가갸글, 국문(國文)[12] 등이 있다.[5]"
     kiwi = Kiwi()

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -14,10 +14,6 @@ class FileReader:
     def __iter__(self):
         yield from open(self.path, encoding='utf-8')
 
-def test_glue_empty():
-    kiwi = Kiwi()
-    kiwi.glue([])
-
 def test_repr():
     kiwi = Kiwi()
     print(repr(kiwi))
@@ -393,6 +389,10 @@ Multilingual을 활용하여 실험한 결과 F1 스코어 46.0%의 성능을 �
     kiwi = Kiwi()
     ret, space_insertions = kiwi.glue(chunks, return_space_insertions=True)
     assert space_insertions == [False, False, True, False, True, True, True]
+
+def test_glue_empty():
+    kiwi = Kiwi()
+    kiwi.glue([])
 
 def test_join():
     kiwi = Kiwi()


### PR DESCRIPTION
#120 에서 제기된 오류를 수정하기 위한 PR. 크게 두 가지 방향에서 수정을 시도했음
* `Kiwi.tokenize`로 분석된 형태소를 다시 결합할때는 기존의 위치정보를 활용해 최대한 원본으 띄어쓰기를 유지하도록 변경
* 이와 별도로 `VCP`태그는 항상 왼쪽 형태소와 붙여쓰도록 수정
* 추가로 `Kiwi.join`에서 tuple의 세번째 요소로 강제 띄어쓰기/붙여쓰기를 설정할 수 있도록 하여 내부적인 띄어쓰기 로직을 덮어쓸 수 있도록 허용