### PR TITLE
fix: KiwiTokenizer __repr__ issue

### DIFF
--- a/kiwipiepy/transformers_addon.py
+++ b/kiwipiepy/transformers_addon.py
@@ -427,8 +427,16 @@ class KiwiTokenizer(PreTrainedTokenizerBase):
     def vocab(self):
         return self._tokenizer.vocab
     
+    @property
+    def vocab_size(self) -> int:
+        return len(self._tokenizer.vocab)
+
     def __len__(self):
         return len(self._tokenizer)
+
+    @property
+    def is_fast(self) -> bool:
+        return False
 
     def convert_tokens_to_ids(self, tokens: Union[str, List[str]]) -> Union[int, List[int]]:
         if tokens is None:


### PR DESCRIPTION
fixes: #133 

`KiwiTokenizer`에 `is_fast`와 `vocab_size`를 추가합니다.

```py
import kiwipiepy.transformers_addon
from transformers import AutoTokenizer

repo = "kiwi-farm/roberta-base-32k"
tk = AutoTokenizer.from_pretrained(repo)
```

```py
tk
```

```py
KiwiTokenizer(name_or_path='kiwi-farm/roberta-base-32k', vocab_size=32000, model_max_length=512, is_fast=False, padding_side='right', truncation_side='right', special_tokens={'bos_token': '[BOS]', 'eos_token': '[EOS]', 'unk_token': '[UNK]', 'sep_token': '[SEP]', 'pad_token': '[PAD]', 'cls_token': '[CLS]', 'mask_token': '[MASK]'}, clean_up_tokenization_spaces=True)
```
