### PR TITLE
fix: SwTokenizer getstate

### DIFF
--- a/kiwipiepy/sw_tokenizer.py
+++ b/kiwipiepy/sw_tokenizer.py
@@ -418,6 +418,9 @@ path: str
     def __repr__(self) -> str:
         return super().__repr__()
 
+    def __getstate__(self):
+        return self.__dict__
+
     @property
     def unk_token(self) -> Optional[str]:
         return self.config.unk_token

--- a/test/test_transformers_addon.py
+++ b/test/test_transformers_addon.py
@@ -92,6 +92,13 @@ def test_tokenize():
     t = tokenizer.tokenize("맞습니다요!")
     assert t == ["맞/V", "습니다/E", "요/J", "!"]
 
+def test_pickle():
+    pickled = pickle.dumps(tokenizer)
+    unpickled_tokenizer = pickle.loads(pickled)
+    ref = tokenizer.tokenize("Unpickled Test")
+    tar = unpickled_tokenizer.tokenize("Unpickled Test")
+    assert ref == tar
+
 if __name__ == '__main__':
     for k, v in locals().copy().items():
         if k.startswith('test'): v()

--- a/test/test_transformers_addon.py
+++ b/test/test_transformers_addon.py
@@ -1,3 +1,4 @@
+import pickle
 
 def test_init():
     from transformers import AutoTokenizer
@@ -92,5 +93,11 @@ def test_tokenize():
     assert t == ["맞/V", "습니다/E", "요/J", "!"]
 
 if __name__ == '__main__':
+    for k, v in locals().copy().items():
+        if k.startswith('test'): v()
+
+    picked = pickle.dumps(tokenizer)
+    tokenizer = pickle.loads(picked)
+
     for k, v in locals().copy().items():
         if k.startswith('test'): v()

--- a/test/test_transformers_addon.py
+++ b/test/test_transformers_addon.py
@@ -96,8 +96,8 @@ if __name__ == '__main__':
     for k, v in locals().copy().items():
         if k.startswith('test'): v()
 
-    picked = pickle.dumps(tokenizer)
-    tokenizer = pickle.loads(picked)
+    pickled = pickle.dumps(tokenizer)
+    tokenizer = pickle.loads(pickled)
 
     for k, v in locals().copy().items():
         if k.startswith('test'): v()

--- a/test/test_transformers_addon.py
+++ b/test/test_transformers_addon.py
@@ -100,4 +100,4 @@ if __name__ == '__main__':
     tokenizer = pickle.loads(pickled)
 
     for k, v in locals().copy().items():
-        if k.startswith('test'): v()
+        if k != 'test_init' and k.startswith('test'): v()


### PR DESCRIPTION
fixes: #135 

https://docs.python.org/ko/3.11/library/pickle.html?highlight=pickle#pickling-class-instances

~~python 3.11부터는 __getstate__가 정의되어있지 않을때의 기본 동작을 정의함으로써 이 문제를 해결한 것으로 보입니다.~~ python 3.11에서도 같은 에러 발생

python 3.10이하에서는 여전히 필요합니다.