### PR TITLE
오타 교정 사용 시 복합 명사 인식이 제대로 안되는 버그 수정

### DIFF
--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -1997,6 +1997,17 @@ ValueError: cannot specify format specifier for Kiwi Token
     def list_all_scripts(self) -> List[str]:
         return super().list_all_scripts()
 
+    def convert_hsdata(
+        self,
+        input_path:Union[str, List[str]],
+        output_path:str,
+        morpheme_def_path:str = None,
+        morpheme_def_min_cnt:int = 0,
+    ):
+        if isinstance(input_path, str):
+            input_path = [input_path]
+        return super().convert_hsdata(input_path, output_path, morpheme_def_path, morpheme_def_min_cnt)
+
     def make_hsdataset(
         self,
         inputs:List[str],

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -921,6 +921,10 @@ def test_saisiot():
         assert tokens[0].tag == "NNG"
 
 def test_issue_kiwi_205():
+    if sys.maxsize <= 2**32:
+        print("[skipped this test in 32bit OS.]", file=sys.stderr)
+        return
+
     kiwi = Kiwi()
     kiwi.add_user_word('함박 스테이크')
     res = kiwi.tokenize('함박 스테이크를 먹었습니다.')

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -919,3 +919,14 @@ def test_saisiot():
         tokens = kiwi.tokenize(s, saisiot=False)
         assert len(tokens) == 1
         assert tokens[0].tag == "NNG"
+
+def test_issue_kiwi_205():
+    kiwi = Kiwi()
+    kiwi.add_user_word('함박 스테이크')
+    res = kiwi.tokenize('함박 스테이크를 먹었습니다.')
+    assert res[0].form == '함박 스테이크'
+
+    kiwi = Kiwi(typos='basic_with_continual')
+    kiwi.add_user_word('함박 스테이크')
+    res = kiwi.tokenize('함박 스테이크를 먹었습니다.')
+    assert res[0].form == '함박 스테이크'


### PR DESCRIPTION
* bab2min/Kiwi#205 수정을 Python측에도 반영