### PR TITLE
Fix Issue 216

### DIFF
--- a/src/PyUtils.h
+++ b/src/PyUtils.h
@@ -40,6 +40,18 @@
 #define PY_STRONG_INLINE __forceinline 
 #endif
 
+#if defined(_WIN32) || defined(_WIN64)
+#define LITTLE_ENDIAN 1
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LITTLE_ENDIAN 1
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define LITTLE_ENDIAN 0
+#else
+#error "Unknown endianness"
+#endif
+#endif
+
 namespace py
 {
 	template<class Ty>
@@ -720,7 +732,8 @@ namespace py
 	{
 		UniqueObj operator()(const std::u16string& v)
 		{
-			return UniqueObj{ PyUnicode_DecodeUTF16((const char*)v.data(), v.size() * 2, nullptr, nullptr) };
+			int byteorder = LITTLE_ENDIAN ? -1 : 1;
+			return UniqueObj{ PyUnicode_DecodeUTF16((const char*)v.data(), v.size() * 2, nullptr, &byteorder) };
 		}
 
 		bool _toCpp(PyObject* obj, std::u16string& out)
@@ -755,7 +768,8 @@ namespace py
 	{
 		UniqueObj operator()(const std::u16string_view& v)
 		{
-			return UniqueObj{ PyUnicode_DecodeUTF16((const char*)v.data(), v.size() * 2, nullptr, nullptr) };
+			int byteorder = LITTLE_ENDIAN ? -1 : 1;
+			return UniqueObj{ PyUnicode_DecodeUTF16((const char*)v.data(), v.size() * 2, nullptr, &byteorder) };
 		}
 	};
 

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -1009,3 +1009,10 @@ def test_dialect():
     assert tokens[3].tagged_form == "드시/VV"
     assert tokens[4].tagged_form in ("엇/EP", "었/EP")
     assert tokens[5].tagged_form == "수과/EF"
+
+def test_issue_216():
+    from kiwipiepy import Kiwi
+    kiwi = Kiwi()
+    tokens = kiwi.tokenize("테스트용\ufeff문자열입니다.")
+    for token in tokens:
+        assert token.form


### PR DESCRIPTION
형태소 분석 결과의 form이 `U+FEFF`로 시작할 때 이 문자열이 Python str타입으로 변환되는 과정에서 U+FEFF가 제거되는 버그 수정