### PR TITLE
pretokenized 입력 범위 검증 오류 수정

### DIFF
--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -1113,13 +1113,15 @@ result: List[Tuple[str, float, int, float]]
         if callable(override_pretokenized):
             spans = override_pretokenized(text)
             if spans: 
-                if not all(0 <= s <= e <= len(text) for s, e, *_ in spans):
+                # 빈 span은 native splitter에서 길이 - 1을 계산하므로 public API에서 막는다.
+                if not all(0 <= s < e <= len(text) for s, e, *_ in spans):
                     raise ValueError("All spans must be valid range of text")
                 span_groups.append(spans)
         elif override_pretokenized is not None:
             spans = override_pretokenized
             if spans: 
-                if not all(0 <= s <= e <= len(text) for s, e, *_ in spans):
+                # 빈 span은 native splitter에서 길이 - 1을 계산하므로 public API에서 막는다.
+                if not all(0 <= s < e <= len(text) for s, e, *_ in spans):
                     raise ValueError("All spans must be valid range of text")
                 span_groups.append(spans)
         
@@ -1565,6 +1567,8 @@ pretokenized: Union[Callable[[str], PretokenizedTokenList], PretokenizedTokenLis
 
     형태소 분석에 앞서 텍스트 내 특정 구간의 형태소 분석 결과를 미리 정의합니다. 이 값에 의해 정의된 텍스트 구간은 항상 해당 방법으로만 토큰화됩니다.
     이 값은 str을 입력 받아 `PretokenizedTokenList`를 반환하는 `Callable`로 주어지거나, `PretokenizedTokenList` 값 단독으로 주어질 수 있습니다.
+    각 외부 구간은 Python code point 기준으로 `0 <= begin < end <= len(text)`를 만족해야 하며,
+    내부 `PretokenizedToken`의 구간도 해당 외부 구간 안에 있어야 합니다.
     `text`가 `Iterable[str]`인 경우 `pretokenized`는 None 혹은 `Callable`로 주어져야 합니다. 자세한 것은 아래 Notes의 예시를 참조하십시오.
 allowed_dialects: Union[Dialect, str]
     .. versionadded:: 0.22.0

--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 #include <fstream>
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <shared_mutex>
 
@@ -1720,6 +1721,18 @@ struct SwTokenizerObject : py::CObject<SwTokenizerObject>
 	}
 };
 
+inline uint32_t toPretokenizedOffset(uint64_t offset)
+{
+	// PretokenizedSpan과 BasicToken은 uint32_t offset만 저장한다. Python int를
+	// 먼저 좁히면 2^32가 0으로 돌아가 유효한 원문 범위처럼 보일 수 있으므로
+	// 변환 전에 공통으로 상한을 검사한다.
+	if (offset > numeric_limits<uint32_t>::max())
+	{
+		throw py::ValueError{ "`pretokenized` offsets must be in the uint32_t range." };
+	}
+	return (uint32_t)offset;
+}
+
 inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpans(PyObject* obj)
 {
 	vector<PretokenizedSpan> ret;
@@ -1732,14 +1745,22 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 	py::foreach<PyObject*>(obj, [&](PyObject* group)
 	{
 		py::foreachVisit<variant<
-			tuple<uint32_t, uint32_t>,
-			tuple<uint32_t, uint32_t, PyObject*>,
-			tuple<uint32_t, uint32_t, PyObject*, PyObject*>
+			tuple<uint64_t, uint64_t>,
+			tuple<uint64_t, uint64_t, PyObject*>,
+			tuple<uint64_t, uint64_t, PyObject*, PyObject*>
 		>>(group, [&](auto&& item)
 		{
 			using T = decay_t<decltype(item)>;
-			ret.emplace_back(PretokenizedSpan{ get<0>(item), get<1>(item) });
-			if constexpr (is_same_v<T, tuple<uint32_t, uint32_t, PyObject*>> || is_same_v<T, tuple<uint32_t, uint32_t, PyObject*, PyObject*>>)
+			const auto begin = toPretokenizedOffset(get<0>(item));
+			const auto end = toPretokenizedOffset(get<1>(item));
+			// 단순 품사 표기에서 end - begin을 저장하기 전에 빈/역방향
+			// span을 거절해 unsigned wraparound가 뒤 경계 검사를 우회하지 않게 한다.
+			if (begin >= end)
+			{
+				throw py::ValueError{ "A `pretokenized` span must be a non-empty range." };
+			}
+			ret.emplace_back(PretokenizedSpan{ begin, end });
+			if constexpr (is_same_v<T, tuple<uint64_t, uint64_t, PyObject*>> || is_same_v<T, tuple<uint64_t, uint64_t, PyObject*, PyObject*>>)
 			{
 				if (PyUnicode_Check(get<2>(item))) // POSTag
 				{
@@ -1749,12 +1770,12 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 					auto& token = ret.back().tokenization.back();
 					token.tag = tag;
 					token.begin = 0;
-					token.end = get<1>(item) - get<0>(item);
+					token.end = end - begin;
 				}
 				else
 				{
-					tuple<u16string, u16string, size_t, size_t> singleItem;
-					if (py::toCpp<tuple<u16string, u16string, size_t, size_t>>(get<2>(item), singleItem))
+					tuple<u16string, u16string, uint64_t, uint64_t> singleItem;
+					if (py::toCpp<tuple<u16string, u16string, uint64_t, uint64_t>>(get<2>(item), singleItem))
 					{
 						auto tag = parseTag(get<1>(singleItem));
 						if (tag == POSTag::max) throw py::ValueError{ "wrong tag value: " + utf16To8(get<1>(singleItem)) };
@@ -1762,12 +1783,12 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 						auto& token = ret.back().tokenization.back();
 						token.form = move(get<0>(singleItem));
 						token.tag = tag;
-						token.begin = get<2>(singleItem);
-						token.end = get<3>(singleItem);
+						token.begin = toPretokenizedOffset(get<2>(singleItem));
+						token.end = toPretokenizedOffset(get<3>(singleItem));
 					}
 					else
 					{
-						py::foreach<tuple<u16string, u16string, size_t, size_t>>(get<2>(item), [&](auto&& i)
+						py::foreach<tuple<u16string, u16string, uint64_t, uint64_t>>(get<2>(item), [&](auto&& i)
 						{
 							auto tag = parseTag(get<1>(i));
 							if (tag == POSTag::max) throw py::ValueError{ "wrong tag value: " + utf16To8(get<1>(i)) };
@@ -1775,14 +1796,14 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 							auto& token = ret.back().tokenization.back();
 							token.form = move(get<0>(i));
 							token.tag = tag;
-							token.begin = get<2>(i);
-							token.end = get<3>(i);
+							token.begin = toPretokenizedOffset(get<2>(i));
+							token.end = toPretokenizedOffset(get<3>(i));
 						}, "");
 					}
 				}
 			}
 
-			if constexpr (is_same_v<T, tuple<uint32_t, uint32_t, PyObject*, PyObject*>>)
+			if constexpr (is_same_v<T, tuple<uint64_t, uint64_t, PyObject*, PyObject*>>)
 			{
 				userValues.emplace_back(py::UniqueObj{ get<3>(item) });
 				Py_INCREF(userValues.back().get());
@@ -1795,7 +1816,7 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 		groupBoundaries.emplace_back(ret.size());
 	}, "`pretokenized` must be an iterable of `Tuple[int, int]`, `Tuple[int, int, str]`, `Tuple[int, int, List[Token]]`");
 
-	if (groupBoundaries.size() > 1)
+	if (groupBoundaries.size() > 1 && !ret.empty())
 	{
 		spanPtrs.reserve(ret.size());
 		size_t g = 0;
@@ -1845,15 +1866,32 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 
 inline void updatePretokenizedSpanToU16(vector<PretokenizedSpan>& spans, const py::StringWithOffset<u16string>& so)
 {
+	const size_t sourceLength = so.offsets.empty() ? 0 : so.offsets.size() - 1;
 	for (auto& s : spans)
 	{
+		// 외부 span과 내부 Token 위치는 Python code point 단위다. UTF-16
+		// 위치표를 참조하기 전에 두 범위를 모두 검증해 잘못된 인덱스를 막는다.
+		if (s.begin >= s.end || s.end > sourceLength)
+		{
+			throw py::ValueError{ "A `pretokenized` span is outside the source text." };
+		}
+		const size_t spanBegin = s.begin;
+		const size_t spanEnd = s.end;
+		const size_t spanLength = spanEnd - spanBegin;
+		const size_t u16SpanBegin = so.offsets[spanBegin];
 		for (auto& t : s.tokenization)
 		{
-			t.begin = so.offsets[s.begin + t.begin] - so.offsets[s.begin];
-			t.end = so.offsets[s.begin + t.end] - so.offsets[s.begin];
+			// 기존 API가 허용하던 zero-length 내부 형태소는 유지하고, 역방향
+			// 위치와 outer span 밖의 위치만 거절해 호환성을 보존한다.
+			if (t.begin > t.end || t.end > spanLength)
+			{
+				throw py::ValueError{ "A token in `pretokenized` is outside its span." };
+			}
+			t.begin = so.offsets[spanBegin + t.begin] - u16SpanBegin;
+			t.end = so.offsets[spanBegin + t.end] - u16SpanBegin;
 		}
-		s.begin = so.offsets[s.begin];
-		s.end = so.offsets[s.end];
+		s.begin = u16SpanBegin;
+		s.end = so.offsets[spanEnd];
 
 		if (s.tokenization.size() == 1 && s.tokenization[0].form.empty())
 		{

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -175,6 +175,71 @@ def test_pretokenized():
     finally:
         assert is_raised
 
+
+def test_pretokenized_ranges_reject_empty_and_overflow():
+    """native 입력도 빈 범위와 uint32 범위를 안전하게 거절한다."""
+    from _kiwipiepy import _Kiwi
+
+    kiwi = Kiwi()
+    native_args = (
+        'AB', 1, Match.ALL, False, None, False, 0, 3.0,
+        None, 2.5,
+    )
+
+    def assert_value_error(fn):
+        try:
+            fn()
+        except ValueError:
+            return
+        raise AssertionError('expected ValueError')
+
+    # 빈 group만 여럿 넘겨도 병합용 임시 배열의 첫 원소를 읽지 않아야 한다.
+    ordinary = _Kiwi.analyze(kiwi, *native_args, None, kiwi.global_config)
+    empty_groups = _Kiwi.analyze(kiwi, *native_args, [[], []], kiwi.global_config)
+    assert [
+        [token.tagged_form for token in tokens] for tokens, _ in empty_groups
+    ] == [
+        [token.tagged_form for token in tokens] for tokens, _ in ordinary
+    ]
+
+    # 공개 래퍼의 사전 검사를 우회하는 native 호출도 zero-width span으로
+    # splitter가 길이 - 1을 계산하지 않도록 ValueError로 끝나야 한다.
+    for pretokenized in [
+        [[(0, 0)]],
+        [[(1, 1)]],
+        [[(2, 1)]],
+        [[(0, 3)]],
+    ]:
+        assert_value_error(lambda pretokenized=pretokenized: _Kiwi.analyze(
+            kiwi, *native_args, pretokenized, kiwi.global_config,
+        ))
+
+    # Python int를 uint32_t로 바로 좁히면 2**32가 0이 된다. outer와 inner
+    # 위치 모두 변환 전에 거절해 잘못된 원문 범위로 분석하지 않게 한다.
+    overflow = 2 ** 32
+    for pretokenized in [
+        [[(overflow, overflow + 1)]],
+        [[(0, 2, ('A', 'SL', overflow, overflow + 1))]],
+    ]:
+        assert_value_error(lambda pretokenized=pretokenized: _Kiwi.analyze(
+            kiwi, *native_args, pretokenized, kiwi.global_config,
+        ))
+
+    for pretokenized in [[(0, 0)], [(1, 1)]]:
+        assert_value_error(lambda pretokenized=pretokenized: kiwi.tokenize(
+            'AB', pretokenized=pretokenized,
+        ))
+
+    invalid_tokens = [
+        PretokenizedToken('A', 'SL', -1, 1),
+        PretokenizedToken('A', 'SL', 1, 0),
+        PretokenizedToken('A', 'SL', 0, 3),
+    ]
+    for token in invalid_tokens:
+        assert_value_error(lambda token=token: kiwi.tokenize(
+            'AB', pretokenized=[(0, 2, token)],
+        ))
+
 def test_re_word():
     text = '{평만경(平滿景)}이 사람을 시켜 {침향(沈香)} 10냥쭝을 바쳤으므로'
 


### PR DESCRIPTION
## 문제

`pretokenized`에 빈 구간, 원문 밖의 구간 또는 내부 표현 범위를 넘는 위치가 전달되면 네이티브 코드에서 위치를 변환하기 전에 충분히 검증되지 않을 수 있습니다.

`just_split` 기능을 검토하는 과정에서 발견했지만, 신규 기능과 독립적으로 재현되는 기존 API 문제이므로 별도 PR로 분리했습니다.

## 변경 사항

- 외부 span이 비어 있거나 역방향인 경우 거부
- 원문 범위를 벗어난 span 거부
- 내부 token 위치가 부모 span 안에 있는지 검증
- `uint32_t` 범위를 넘는 위치가 변환 과정에서 잘리지 않도록 검증
- 비어 있는 pretokenized group을 안전하게 처리

기존에 허용되던 zero-length 내부 token은 유지하고, 외부 span만 비어 있지 않은 구간으로 제한합니다.

## 테스트

다음 경계 사례에 대한 회귀 테스트를 추가했습니다.

- 빈 외부 span
- 역방향 및 원문 밖의 span
- 부모 span 밖의 내부 token
- `uint32_t` 범위를 넘는 위치
- 비어 있는 여러 pretokenized group