### PR TITLE
pretokenized 사용 시 non-BMP 문자 뒤 Token 위치 오류 수정

### DIFF
--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -1230,7 +1230,9 @@ inline const char* getTagStr(const POSTag tag, const u16string& form)
 	return tagToString(tag);
 }
 
-py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj, const shared_ptr<Kiwi>& kiwiInst, vector<py::UniqueObj>&& userValues = {})
+py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj,
+	const shared_ptr<Kiwi>& kiwiInst, vector<py::UniqueObj>&& userValues = {},
+	const vector<size_t>* sourceOffsets = nullptr)
 {
 	// set the following objects semi-immortal. (they are neither freed nor managed)
 	// it prevents crashes at Python3.12
@@ -1249,7 +1251,7 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj, 
 		for (auto& q : p.first)
 		{
 			size_t u32chrs = 0;
-			for (auto u : q.str)
+			if (!sourceOffsets) for (auto u : q.str)
 			{
 				if ((u & 0xFC00) == 0xD800) u32chrs++;
 			}
@@ -1261,8 +1263,22 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj, 
 			tItem->_rawTag = q.tag;
 			tItem->resultHash = resultHash;
 			tItem->_tag = getTagStr(q.tag, tItem->_form);
-			tItem->_pos = q.position - u32offset;
-			tItem->_len = q.length - u32chrs;
+			if (sourceOffsets)
+			{
+				const size_t sourceBegin = q.position;
+				const size_t sourceEnd = sourceBegin + q.length;
+				const size_t pyBegin = upper_bound(sourceOffsets->begin(), sourceOffsets->end(), sourceBegin)
+					- sourceOffsets->begin() - 1;
+				const size_t pyEnd = lower_bound(sourceOffsets->begin(), sourceOffsets->end(), sourceEnd)
+					- sourceOffsets->begin();
+				tItem->_pos = (uint32_t)pyBegin;
+				tItem->_len = (uint32_t)(pyEnd - pyBegin);
+			}
+			else
+			{
+				tItem->_pos = q.position - u32offset;
+				tItem->_len = q.length - u32chrs;
+			}
 			tItem->_wordPosition = q.wordPosition;
 			tItem->_sentPosition = q.sentPosition;
 			tItem->_subSentPosition = q.subSentPosition;
@@ -1311,7 +1327,7 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj, 
 			}
 
 			PyList_SetItem(rList.get(), jdx++, (PyObject*)tItem.release());
-			u32offset += u32chrs;
+			if (!sourceOffsets) u32offset += u32chrs;
 		}
 		PyList_SetItem(retList.get(), idx++, py::buildPyTuple(move(rList), p.second).release());
 	}
@@ -1891,7 +1907,9 @@ auto makeFutureCarrier(std::future<FutureTy>&& future, CarriedTy&& carried)
 	return FutureCarrier<FutureTy, std::remove_reference_t<CarriedTy>>{ std::move(future), std::forward<CarriedTy>(carried) };
 }
 
-struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, FutureCarrier<vector<TokenResult>, vector<py::UniqueObj>>>
+using AnalysisContext = pair<vector<py::UniqueObj>, vector<size_t>>;
+
+struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, FutureCarrier<vector<TokenResult>, AnalysisContext>>
 {
 	py::UniqueCObj<KiwiObject> kiwi;
 	std::shared_ptr<Kiwi> kiwiInst;
@@ -1913,12 +1931,16 @@ struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, Fut
 		waitQueue();
 	}
 
-	py::UniqueObj buildPy(pair<vector<TokenResult>, vector<py::UniqueObj>>&& v)
+	py::UniqueObj buildPy(pair<vector<TokenResult>, AnalysisContext>&& v)
 	{
 		return py::handleExc([&]()
 		{
 			if (v.first.size() > topN) v.first.erase(v.first.begin() + topN, v.first.end());
-			return resToPyList(move(v.first), kiwi.get(), kiwiInst, move(v.second));
+			auto context = move(v.second);
+			return resToPyList(
+				move(v.first), kiwi.get(), kiwiInst, move(context.first),
+				context.second.empty() ? nullptr : &context.second
+			);
 		});
 	}
 
@@ -1948,7 +1970,7 @@ struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, Fut
 				move(pretokenized.first),
 				config
 			),
-			move(pretokenized.second)
+			AnalysisContext{ move(pretokenized.second), move(so.offsets) }
 		);
 	}
 };
@@ -2367,7 +2389,10 @@ py::UniqueObj KiwiObject::analyze(PyObject* text, size_t topN,
 		}
 		auto res = kiwiInst->analyze(so.str, topN, AnalyzeOption{ matchOptions, morphs, openEnding, allowedDialects, dialectCost, ptt, typoCostThreshold }, pretokenizedSpans.first, cConfig);
 		if (res.size() > topN) res.erase(res.begin() + topN, res.end());
-		return resToPyList(move(res), this, kiwiInst, move(pretokenizedSpans.second));
+		return resToPyList(
+			move(res), this, kiwiInst, move(pretokenizedSpans.second),
+			so.offsets.empty() ? nullptr : &so.offsets
+		);
 	}
 	else
 	{

--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -1231,9 +1231,11 @@ inline const char* getTagStr(const POSTag tag, const u16string& form)
 	return tagToString(tag);
 }
 
-py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj,
-	const shared_ptr<Kiwi>& kiwiInst, vector<py::UniqueObj>&& userValues = {},
-	const vector<size_t>* sourceOffsets = nullptr)
+py::UniqueObj resToPyList(vector<TokenResult>&& res, 
+	const KiwiObject* kiwiObj,
+	const shared_ptr<Kiwi>& kiwiInst, 
+	const py::SurrogateOffsetMap& sourceOffsets,
+	vector<py::UniqueObj>&& userValues = {})
 {
 	// set the following objects semi-immortal. (they are neither freed nor managed)
 	// it prevents crashes at Python3.12
@@ -1247,16 +1249,9 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj,
 	{
 		py::UniqueObj rList{ PyList_New(p.first.size()) };
 		size_t jdx = 0;
-		size_t u32offset = 0;
 		const size_t resultHash = hashTokenInfo(p.first);
 		for (auto& q : p.first)
 		{
-			size_t u32chrs = 0;
-			if (!sourceOffsets) for (auto u : q.str)
-			{
-				if ((u & 0xFC00) == 0xD800) u32chrs++;
-			}
-
 			auto tItem = py::makeNewObject<TokenObject>();
 			tItem->kiwiInst = kiwiInst;
 			tItem->_form = move(q.str);
@@ -1264,22 +1259,10 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj,
 			tItem->_rawTag = q.tag;
 			tItem->resultHash = resultHash;
 			tItem->_tag = getTagStr(q.tag, tItem->_form);
-			if (sourceOffsets)
-			{
-				const size_t sourceBegin = q.position;
-				const size_t sourceEnd = sourceBegin + q.length;
-				const size_t pyBegin = upper_bound(sourceOffsets->begin(), sourceOffsets->end(), sourceBegin)
-					- sourceOffsets->begin() - 1;
-				const size_t pyEnd = lower_bound(sourceOffsets->begin(), sourceOffsets->end(), sourceEnd)
-					- sourceOffsets->begin();
-				tItem->_pos = (uint32_t)pyBegin;
-				tItem->_len = (uint32_t)(pyEnd - pyBegin);
-			}
-			else
-			{
-				tItem->_pos = q.position - u32offset;
-				tItem->_len = q.length - u32chrs;
-			}
+			const size_t chrBegin = sourceOffsets.toChrFloor(q.position);
+			const size_t chrEnd = sourceOffsets.toChrCeil((size_t)q.position + q.length);
+			tItem->_pos = (uint32_t)chrBegin;
+			tItem->_len = (uint32_t)(chrEnd - chrBegin);
 			tItem->_wordPosition = q.wordPosition;
 			tItem->_sentPosition = q.sentPosition;
 			tItem->_subSentPosition = q.subSentPosition;
@@ -1328,7 +1311,6 @@ py::UniqueObj resToPyList(vector<TokenResult>&& res, const KiwiObject* kiwiObj,
 			}
 
 			PyList_SetItem(rList.get(), jdx++, (PyObject*)tItem.release());
-			if (!sourceOffsets) u32offset += u32chrs;
 		}
 		PyList_SetItem(retList.get(), idx++, py::buildPyTuple(move(rList), p.second).release());
 	}
@@ -1882,7 +1864,7 @@ inline pair<vector<PretokenizedSpan>, vector<py::UniqueObj>> makePretokenizedSpa
 
 inline void updatePretokenizedSpanToU16(vector<PretokenizedSpan>& spans, const py::StringWithOffset<u16string>& so)
 {
-	const size_t sourceLength = so.offsets.empty() ? 0 : so.offsets.size() - 1;
+	const size_t sourceLength = so.offsets.chrSize;
 	for (auto& s : spans)
 	{
 		// 외부 span과 내부 Token 위치는 Python code point 단위다. UTF-16
@@ -1894,7 +1876,7 @@ inline void updatePretokenizedSpanToU16(vector<PretokenizedSpan>& spans, const p
 		const size_t spanBegin = s.begin;
 		const size_t spanEnd = s.end;
 		const size_t spanLength = spanEnd - spanBegin;
-		const size_t u16SpanBegin = so.offsets[spanBegin];
+		const size_t u16SpanBegin = so.offsets.toU16(spanBegin);
 		for (auto& t : s.tokenization)
 		{
 			// 기존 API가 허용하던 zero-length 내부 형태소는 유지하고, 역방향
@@ -1903,11 +1885,11 @@ inline void updatePretokenizedSpanToU16(vector<PretokenizedSpan>& spans, const p
 			{
 				throw py::ValueError{ "A token in `pretokenized` is outside its span." };
 			}
-			t.begin = so.offsets[spanBegin + t.begin] - u16SpanBegin;
-			t.end = so.offsets[spanBegin + t.end] - u16SpanBegin;
+			t.begin = so.offsets.toU16(spanBegin + t.begin) - u16SpanBegin;
+			t.end = so.offsets.toU16(spanBegin + t.end) - u16SpanBegin;
 		}
 		s.begin = u16SpanBegin;
-		s.end = so.offsets[spanEnd];
+		s.end = so.offsets.toU16(spanEnd);
 
 		if (s.tokenization.size() == 1 && s.tokenization[0].form.empty())
 		{
@@ -1945,7 +1927,11 @@ auto makeFutureCarrier(std::future<FutureTy>&& future, CarriedTy&& carried)
 	return FutureCarrier<FutureTy, std::remove_reference_t<CarriedTy>>{ std::move(future), std::forward<CarriedTy>(carried) };
 }
 
-using AnalysisContext = pair<vector<py::UniqueObj>, vector<size_t>>;
+struct AnalysisContext
+{
+	vector<py::UniqueObj> userValues;
+	py::SurrogateOffsetMap sourceOffsets;
+};
 
 struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, FutureCarrier<vector<TokenResult>, AnalysisContext>>
 {
@@ -1976,8 +1962,7 @@ struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, Fut
 			if (v.first.size() > topN) v.first.erase(v.first.begin() + topN, v.first.end());
 			auto context = move(v.second);
 			return resToPyList(
-				move(v.first), kiwi.get(), kiwiInst, move(context.first),
-				context.second.empty() ? nullptr : &context.second
+				move(v.first), kiwi.get(), kiwiInst, context.sourceOffsets, move(context.userValues)
 			);
 		});
 	}
@@ -1992,18 +1977,13 @@ struct KiwiResIter : public py::ResultIter<KiwiResIter, vector<TokenResult>, Fut
 			py::UniqueObj ptResult{ PyObject_CallFunctionObjArgs(pretokenizedCallable.get(), next.get(), nullptr) };
 			pretokenized = makePretokenizedSpans(ptResult.get());
 		}
-		py::StringWithOffset<u16string> so;
-		if (pretokenized.first.empty())
+		auto so = py::toCpp<py::StringWithOffset<u16string>>(next);
+		if (!pretokenized.first.empty())
 		{
-			so.str = py::toCpp<u16string>(next);
-		}
-		else
-		{
-			so = py::toCpp<py::StringWithOffset<u16string>>(next);
 			updatePretokenizedSpanToU16(pretokenized.first, so);
 		}
 		return makeFutureCarrier(
-			kiwiInst->asyncAnalyze(move(so.str), topN, 
+			kiwiInst->asyncAnalyze(move(so.str), topN,
 				options,
 				move(pretokenized.first),
 				config
@@ -2072,7 +2052,9 @@ inline void chrOffsetsToTokenOffsets(const vector<TokenInfo>& tokens, vector<pai
 	}
 }
 
-using TokenEncodeResult = tuple<vector<TokenResult>, vector<uint32_t>, vector<pair<uint32_t, uint32_t>>>;
+// 이 경로는 원본을 UTF-8로 넘기지만 Kiwi가 돌려주는 Token 위치는 UTF-16 기준이므로,
+// 파이썬 코드포인트 단위로 되돌리기 위한 대응표를 결과와 함께 나른다.
+using TokenEncodeResult = tuple<vector<TokenResult>, vector<uint32_t>, vector<pair<uint32_t, uint32_t>>, py::SurrogateOffsetMap>;
 
 struct SwTokenizerResTEIter : public py::ResultIter<SwTokenizerResTEIter, TokenEncodeResult>
 {
@@ -2090,8 +2072,8 @@ struct SwTokenizerResTEIter : public py::ResultIter<SwTokenizerResTEIter, TokenE
 
 	py::UniqueObj buildPy(TokenEncodeResult&& v)
 	{
-		if (returnOffsets) return py::buildPyTuple(resToPyList(move(get<0>(v)), tokenizer->kiwi.get(), tokenizer->kiwiInst), get<1>(v), get<2>(v));
-		return py::buildPyTuple(resToPyList(move(get<0>(v)), tokenizer->kiwi.get(), tokenizer->kiwiInst), get<1>(v));
+		if (returnOffsets) return py::buildPyTuple(resToPyList(move(get<0>(v)), tokenizer->kiwi.get(), tokenizer->kiwiInst, get<3>(v)), get<1>(v), get<2>(v));
+		return py::buildPyTuple(resToPyList(move(get<0>(v)), tokenizer->kiwi.get(), tokenizer->kiwiInst, get<3>(v)), get<1>(v));
 	}
 
 	future<TokenEncodeResult> feedNext(py::SharedObj&& next)
@@ -2099,14 +2081,16 @@ struct SwTokenizerResTEIter : public py::ResultIter<SwTokenizerResTEIter, TokenE
 		if (!PyUnicode_Check(next)) throw py::ValueError{ "`tokenize_encode` requires an instance of `str` or an iterable of `str`." };
 		auto* pool = tokenizer->kiwiInst->getThreadPool();
 		if (!pool) throw py::RuntimeError{ "async mode is unavailable in num_workers == 0" };
-		return pool->enqueue([&](size_t, const string& text)
+		py::SurrogateOffsetMap sourceOffsets;
+		if (!py::buildSurrogateOffsetMap(next.get(), sourceOffsets)) throw py::ExcPropagation{};
+		return pool->enqueue([&](size_t, const string& text, py::SurrogateOffsetMap so)
 		{
 			vector<pair<uint32_t, uint32_t>> offsets;
 			auto res = tokenizer->kiwiInst->analyze(text, 1, Match::allWithNormalizing | Match::zCoda);
 			auto tokenIds = tokenizer->tokenizer.encode(res[0].first.data(), res[0].first.size(), returnOffsets ? &offsets : nullptr);
 			if (returnOffsets) chrOffsetsToTokenOffsets(res[0].first, offsets);
-			return make_tuple(move(res), move(tokenIds), move(offsets));
-		}, py::toCpp<string>(next));
+			return make_tuple(move(res), move(tokenIds), move(offsets), move(so));
+		}, py::toCpp<string>(next), move(sourceOffsets));
 	}
 };
 
@@ -2188,16 +2172,18 @@ py::UniqueObj SwTokenizerObject::tokenizeAndEncode(PyObject* text, bool returnOf
 	if (PyUnicode_Check(text))
 	{
 		vector<pair<uint32_t, uint32_t>> offsets;
+		py::SurrogateOffsetMap sourceOffsets;
+		if (!py::buildSurrogateOffsetMap(text, sourceOffsets)) throw py::ExcPropagation{};
 		auto res = kiwiInst->analyze(py::toCpp<string>(text), 1, Match::allWithNormalizing | Match::zCoda);
 		auto tokenIds = tokenizer.encode(res[0].first.data(), res[0].first.size(), returnOffsets ? &offsets : nullptr);
 		if (returnOffsets)
 		{
 			chrOffsetsToTokenOffsets(res[0].first, offsets);
-			return py::buildPyTuple(resToPyList(move(res), kiwi.get(), kiwiInst), tokenIds, offsets);
+			return py::buildPyTuple(resToPyList(move(res), kiwi.get(), kiwiInst, sourceOffsets), tokenIds, offsets);
 		}
 		else
 		{
-			return py::buildPyTuple(resToPyList(move(res), kiwi.get(), kiwiInst), tokenIds);
+			return py::buildPyTuple(resToPyList(move(res), kiwi.get(), kiwiInst, sourceOffsets), tokenIds);
 		}
 	}
 
@@ -2415,22 +2401,14 @@ py::UniqueObj KiwiObject::analyze(PyObject* text, size_t topN,
 			pretokenizedSpans = makePretokenizedSpans(pretokenized);
 		}
 
-		py::StringWithOffset<u16string> so;
-		if (pretokenizedSpans.first.empty())
+		auto so = py::toCpp<py::StringWithOffset<u16string>>(text);
+		if (!pretokenizedSpans.first.empty())
 		{
-			so.str = py::toCpp<u16string>(text);
-		}
-		else
-		{
-			so = py::toCpp<py::StringWithOffset<u16string>>(text);
 			updatePretokenizedSpanToU16(pretokenizedSpans.first, so);
 		}
 		auto res = kiwiInst->analyze(so.str, topN, AnalyzeOption{ matchOptions, morphs, openEnding, allowedDialects, dialectCost, ptt, typoCostThreshold }, pretokenizedSpans.first, cConfig);
 		if (res.size() > topN) res.erase(res.begin() + topN, res.end());
-		return resToPyList(
-			move(res), this, kiwiInst, move(pretokenizedSpans.second),
-			so.offsets.empty() ? nullptr : &so.offsets
-		);
+		return resToPyList(move(res), this, kiwiInst, so.offsets, move(pretokenizedSpans.second));
 	}
 	else
 	{

--- a/src/PyUtils.h
+++ b/src/PyUtils.h
@@ -299,11 +299,56 @@ namespace py
 	using UniqueObj = UniqueCObj<>;
 	using SharedObj = SharedCObj<>;
 
+	/**
+	 * @brief 파이썬 문자열의 코드포인트 인덱스와 UTF-16 인덱스 사이를 오가는 대응표.
+	 *
+	 * 두 인덱스 공간은 non-BMP 문자(UTF-16에서 서로게이트 쌍 2칸을 차지)에서만 어긋나므로
+	 * 그 문자들의 UTF-16 시작 위치만 오름차순으로 들고 있으면 충분.
+	 */
+	struct SurrogateOffsetMap
+	{
+		std::vector<uint32_t> nonBmpPos;
+		size_t chrSize = 0;
+
+		size_t toU16(size_t chrPos) const
+		{
+			if (nonBmpPos.empty()) return chrPos;
+			size_t lo = 0, hi = nonBmpPos.size();
+			while (lo < hi)
+			{
+				const size_t mid = lo + (hi - lo) / 2;
+				if (nonBmpPos[mid] - mid < chrPos) lo = mid + 1;
+				else hi = mid;
+			}
+			return chrPos + lo;
+		}
+
+		size_t toChrFloor(size_t u16Pos) const
+		{
+			if (nonBmpPos.empty()) return u16Pos;
+			return u16Pos - countBefore(u16Pos);
+		}
+
+		size_t toChrCeil(size_t u16Pos) const
+		{
+			if (nonBmpPos.empty()) return u16Pos;
+			const size_t cnt = countBefore(u16Pos);
+			const bool insidePair = cnt > 0 && u16Pos > 0 && nonBmpPos[cnt - 1] == u16Pos - 1;
+			return u16Pos - cnt + (insidePair ? 1 : 0);
+		}
+
+	private:
+		size_t countBefore(size_t u16Pos) const
+		{
+			return std::lower_bound(nonBmpPos.begin(), nonBmpPos.end(), u16Pos) - nonBmpPos.begin();
+		}
+	};
+
 	template<class Ty>
 	struct StringWithOffset
 	{
 		Ty str;
-		std::vector<size_t> offsets;
+		SurrogateOffsetMap offsets;
 	};
 
 	class ForeachFailed : public std::runtime_error
@@ -727,6 +772,65 @@ namespace py
 		}
 	};
 
+	/**
+	 * @brief 파이썬 문자열을 UTF-16 문자열로 변환한다.
+	 */
+	inline bool pyStrToU16(PyObject* obj, std::u16string& out, SurrogateOffsetMap* map = nullptr)
+	{
+		UniqueObj uobj{ PyUnicode_FromObject(obj) };
+		if (!uobj) return false;
+		const size_t len = PyUnicode_GetLength(uobj.get());
+		auto buf = std::make_unique<Py_UCS4[]>(len);
+		if (!PyUnicode_AsUCS4(uobj.get(), buf.get(), len, 0)) return false;
+
+		out.reserve(len);
+		if (map) map->chrSize = len;
+		for (size_t i = 0; i < len; ++i)
+		{
+			auto c = buf[i];
+			if (c < 0x10000)
+			{
+				out.push_back(c);
+			}
+			else
+			{
+				if (map) map->nonBmpPos.emplace_back((uint32_t)out.size());
+				out.push_back(0xD800 - (0x10000 >> 10) + (c >> 10));
+				out.push_back(0xDC00 + (c & 0x3FF));
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @brief UTF-16 문자열을 따로 만들지 않고 대응표만 채운다.
+	 */
+	inline bool buildSurrogateOffsetMap(PyObject* obj, SurrogateOffsetMap& out)
+	{
+		UniqueObj uobj{ PyUnicode_FromObject(obj) };
+		if (!uobj) return false;
+		const size_t len = PyUnicode_GetLength(uobj.get());
+		auto buf = std::make_unique<Py_UCS4[]>(len);
+		if (!PyUnicode_AsUCS4(uobj.get(), buf.get(), len, 0)) return false;
+
+		out.chrSize = len;
+		out.nonBmpPos.clear();
+		size_t u16Size = 0;
+		for (size_t i = 0; i < len; ++i)
+		{
+			if (buf[i] < 0x10000)
+			{
+				u16Size += 1;
+			}
+			else
+			{
+				out.nonBmpPos.emplace_back((uint32_t)u16Size);
+				u16Size += 2;
+			}
+		}
+		return true;
+	}
+
 	template<>
 	struct ValueBuilder<std::u16string>
 	{
@@ -738,27 +842,7 @@ namespace py
 
 		bool _toCpp(PyObject* obj, std::u16string& out)
 		{
-			UniqueObj uobj{ PyUnicode_FromObject(obj) };
-			if (!uobj) return false;
-			const size_t len = PyUnicode_GetLength(uobj.get());
-			out.reserve(len);
-			auto buf = std::make_unique<Py_UCS4[]>(len);
-			if (!PyUnicode_AsUCS4(uobj.get(), buf.get(), len, 0)) return false;
-
-			for (size_t i = 0; i < len; ++i)
-			{
-				auto c = buf[i];
-				if (c < 0x10000)
-				{
-					out.push_back(c);
-				}
-				else
-				{
-					out.push_back(0xD800 - (0x10000 >> 10) + (c >> 10));
-					out.push_back(0xDC00 + (c & 0x3FF));
-				}
-			}
-			return true;
+			return pyStrToU16(obj, out);
 		}
 	};
 
@@ -778,31 +862,7 @@ namespace py
 	{
 		bool _toCpp(PyObject* obj, StringWithOffset<std::u16string>& out)
 		{
-			UniqueObj uobj{ PyUnicode_FromObject(obj) };
-			if (!uobj) return false;
-			const size_t len = PyUnicode_GetLength(uobj.get());
-			auto buf = std::make_unique<Py_UCS4[]>(len);
-			if (!PyUnicode_AsUCS4(uobj.get(), buf.get(), len, 0)) return false;
-
-			out.str.reserve(len);
-			out.offsets.reserve(len);
-			for (size_t i = 0; i < len; ++i)
-			{
-				auto c = buf[i];
-				if (c < 0x10000)
-				{
-					out.offsets.emplace_back(out.str.size());
-					out.str.push_back(c);
-				}
-				else
-				{
-					out.offsets.emplace_back(out.str.size());
-					out.str.push_back(0xD800 - (0x10000 >> 10) + (c >> 10));
-					out.str.push_back(0xDC00 + (c & 0x3FF));
-				}
-			}
-			out.offsets.emplace_back(out.str.size());
-			return true;
+			return pyStrToU16(obj, out.str, &out.offsets);
 		}
 	};
 

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -197,6 +197,28 @@ def test_pretokenized_non_bmp_offsets():
         for tokens in kiwi.tokenize(iter(texts), pretokenized=pretokenized)
     ] == [expected, expected]
 
+def test_non_bmp_offsets():
+    # UTF-16에서 두 칸을 차지하는 non-BMP 문자가 섞여 있어도 Token 위치는 파이썬 문자 기준이어야 한다.
+    kiwi = Kiwi()
+
+    assert [
+        (token.form, token.start, token.end) for token in kiwi.tokenize('😀 밥을 먹었다')
+    ] == [('😀', 0, 1), ('밥', 2, 3), ('을', 3, 4), ('먹', 5, 6), ('었', 6, 7), ('다', 7, 8)]
+
+    assert [
+        (token.form, token.start, token.end) for token in kiwi.tokenize('밥😀😀 먹었다')
+    ] == [('밥', 0, 1), ('😀', 1, 2), ('😀', 2, 3), ('먹', 4, 5), ('었', 5, 6), ('다', 6, 7)]
+
+    texts = ['오늘 밥을 먹었다', '𠀀 밥을 먹었다', '🇰🇷 밥을 먹었다']
+    for text, tokens in zip(texts, kiwi.tokenize(iter(texts))):
+        for token in tokens:
+            assert token.end <= len(text)
+            assert text[token.start:token.end] == token.form
+
+    text = '😀 안녕하세요. 반갑습니다.'
+    for sent in kiwi.split_into_sents(text):
+        assert text[sent.start:sent.end] == sent.text
+
 def test_pretokenized_ranges_reject_empty_and_overflow():
     """native 입력도 빈 범위와 uint32 범위를 안전하게 거절한다."""
     from _kiwipiepy import _Kiwi
@@ -508,6 +530,26 @@ def test_swtokenizer_tokenize_encode():
         ref_morphs = tokenizer.kiwi.tokenize(sent, normalize_coda=True, z_coda=True)
         assert [m.tagged_form for m in morphs] == [m.tagged_form for m in ref_morphs]
         assert token_ids.tolist() == ref_token_ids.tolist()
+
+def test_swtokenizer_tokenize_encode_non_bmp_offsets():
+    # tokenize_encode는 원본을 UTF-8로 넘기지만 Token 위치는 파이썬 문자 기준으로 돌아와야 한다.
+    tokenizer = sw_tokenizer.SwTokenizer('Kiwi/test/written.tokenizer.json', num_workers=1)
+    sents = [
+        "😀 한국어에 특화된 토크나이저입니다.",
+        "한국어😀에 특화된 토크나이저입니다.",
+    ]
+
+    def assert_offsets(morphs, sent):
+        assert all(m.end <= len(sent) for m in morphs)
+        emoji = next(m for m in morphs if m.form == '😀')
+        assert sent[emoji.start:emoji.end] == '😀'
+
+    for sent in sents:
+        morphs, token_ids = tokenizer.tokenize_encode(sent)
+        assert_offsets(morphs, sent)
+
+    for (morphs, token_ids), sent in zip(tokenizer.tokenize_encode(iter(sents)), sents):
+        assert_offsets(morphs, sent)
 
 def test_swtokenizer_offset():
     tokenizer = sw_tokenizer.SwTokenizer('Kiwi/tokenizers/kor.32k.json', num_workers=1)

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -175,6 +175,28 @@ def test_pretokenized():
     finally:
         assert is_raised
 
+def test_pretokenized_non_bmp_offsets():
+    kiwi = Kiwi()
+    texts = ['AB', '😀A']
+
+    def pretokenized(value):
+        return [(0, len(value), [
+            PretokenizedToken('X', 'NNP', 0, 1),
+            PretokenizedToken('A', 'SL', 1, 2),
+        ])]
+
+    expected = [('X', 0, 1), ('A', 1, 2)]
+    for text in texts:
+        assert [
+            (token.form, token.start, token.end)
+            for token in kiwi.tokenize(text, pretokenized=pretokenized(text))
+        ] == expected
+
+    assert [
+        [(token.form, token.start, token.end) for token in tokens]
+        for tokens in kiwi.tokenize(iter(texts), pretokenized=pretokenized)
+    ] == [expected, expected]
+
 def test_re_word():
     text = '{평만경(平滿景)}이 사람을 시켜 {침향(沈香)} 10냥쭝을 바쳤으므로'
 


### PR DESCRIPTION

안녕하세요. 
`just_split` 옵션을 구현하다가 codex가 별도로 찾은 문제를 확인하고 검토 후 pr을 작성합니다.

---

## 문제

`pretokenized`로 지정한 구간에 이모지처럼 UTF-16에서 두 칸을 차지하는 문자가 있고, 지정한 형태가 원문과 다르면 반환되는 `Token.start/end`가 Python 문자열의 위치와 맞지 않을 수 있습니다.

예를 들어 길이가 2인 원문 `😀A` 전체를 `X`, `A`로 지정하면 기존 결과는 다음과 같이 원문 길이를 벗어납니다.

```text
기존: X (0, 2), A (2, 3)
수정: X (0, 1), A (1, 2)
```

## 원인

Python 문자열 위치는 문자 단위이지만 Kiwi 내부 위치는 UTF-16 단위입니다. 기존 반환 변환은 분석 결과의 `Token.form`을 기준으로 두 단위를 맞췄습니다. 일반 분석에서는 이 방식이 동작하지만, `pretokenized`에서는 사용자가 지정한 `form`이 원문과 다를 수 있으므로 원문의 non-BMP 문자를 반영하지 못합니다.

## 변경 내용

- `pretokenized` 입력을 UTF-16으로 바꿀 때 이미 만드는 원문 위치표를 결과 변환에도 사용합니다.
- 문자열 하나를 분석하는 경우와 여러 문자열을 순서대로 분석하는 경우에 같은 위치표를 전달합니다.
- `pretokenized`를 사용하지 않는 기존 분석 경로는 그대로 둡니다.

## 테스트

- BMP 문자만 있는 입력에서 기존 위치가 유지되는지 확인했습니다.
- non-BMP 문자가 있는 입력에서 Python 문자 기준 위치가 반환되는지 확인했습니다.
- 문자열 하나와 여러 문자열 입력을 모두 확인했습니다.

수정 전에는 non-BMP 사례가 `[("X", 0, 2), ("A", 2, 3)]`으로 실패했고,
수정 후에는 기존 `pretokenized` 테스트와 새 회귀 테스트가 모두 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token and sentence offsets when text contains non-BMP Unicode characters, such as emoji.
  * Improved offset handling across standard, asynchronous, pretokenized, iterable, and encoded tokenization workflows.
  * Preserved correct behavior for zero-length tokenization and validated token boundaries.

* **Tests**
  * Added regression coverage for Unicode-aware offsets across tokenization and sentence-splitting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->