### PR TITLE
Kiwi.split으로 원문 표면형 기반 분할 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,7 @@ kiwi을 생성하고, 사용자 사전에 단어를 추가하는 작업이 완�
 ```python
 Kiwi.tokenize(text, match_option, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
 Kiwi.analyze(text, top_n, match_option, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
+Kiwi.split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
 Kiwi.split_into_sents(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, return_tokens=False)
 Kiwi.glue(text_chunks, insert_new_lines=None, return_space_insertions=False)
 Kiwi.space(text, reset_whitespace=False)
@@ -851,6 +852,23 @@ Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 SystemError: <built-in function next> returned a result with an error set
 ```
+</details>
+<hr>
+
+<details>
+<summary><code>split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)</code></summary>
+
+형태소 분석 경계에 맞춰 원문의 표면형을 나눕니다. 각 결과는 표면형과 품사 태그, 원문 내 시작 위치와 길이를 담은 `SplitToken`입니다. 하나의 표면형에 여러 형태소가 대응하면 품사 태그를 분석 결과 순서대로 `+`로 연결합니다.
+
+```python
+>> kiwi.split('했다')
+[SplitToken(form='했', tag='VV+EP', start=0, len=1),
+ SplitToken(form='다', tag='EF', start=1, len=1)]
+>> kiwi.split('랠프 월도 에머슨')
+[SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
+```
+
+Token이 없는 원문 구간은 결과에서 제외하지만, 하나의 Token 구간 안에 포함된 공백은 원문 그대로 보존합니다. `text`가 str의 iterable이면 여러 입력을 병렬로 처리하며, `echo=True`이면 각 분할 결과와 원문을 함께 반환합니다.
 </details>
 <hr>
 

--- a/kiwipiepy/__init__.py
+++ b/kiwipiepy/__init__.py
@@ -6,6 +6,7 @@ from kiwipiepy._version import __version__
 from kiwipiepy._wrap import (
     Kiwi, 
     KiwiConfig,
+    SplitToken,
     Sentence, 
     TypoTransformer, 
     TypoDefinition, 
@@ -29,6 +30,7 @@ from kiwipiepy.default_typo_transformer import (
 )
 
 Kiwi.__module__ = 'kiwipiepy'
+SplitToken.__module__ = 'kiwipiepy'
 Sentence.__module__ = 'kiwipiepy'
 TypoTransformer.__module__ = 'kiwipiepy'
 TypoDefinition.__module__ = 'kiwipiepy'

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -13,13 +13,27 @@ from kiwipiepy.utils import Stopwords
 from kiwipiepy.const import Match, Dialect
 from kiwipiepy.template import Template
 
+
+@dataclass
+class SplitToken:
+    '''원문의 표면형을 보존한 분할 결과를 담는 데이터 클래스입니다.
+
+    `form`은 원문에서 잘라낸 표면형이며, `tag`는 해당 구간에 대응하는
+    형태소들의 품사 태그를 분석 결과 순서대로 `+`로 연결한 값입니다.
+    `start`와 `len`은 입력 텍스트 내 위치와 길이를 문자 단위로 나타냅니다.
+    '''
+    form: str
+    tag: str
+    start: int
+    len: int
+
+
 def _split_by_spans(
     text: str,
     tokens: List[Token],
-    return_tags: bool = False,
-) -> Union[List[str], List[Tuple[str, str]]]:
+) -> List[SplitToken]:
     spans = []
-    token_span_indices = [None] * len(tokens) if return_tags else None
+    token_span_indices = [None] * len(tokens)
     sorted_token_indices = sorted(
         range(len(tokens)),
         key=lambda i: (tokens[i].start, tokens[i].end),
@@ -32,12 +46,7 @@ def _split_by_spans(
             spans[-1][1] = max(spans[-1][1], end)
         else:
             spans.append([start, end])
-        if token_span_indices is not None:
-            token_span_indices[token_index] = len(spans) - 1
-
-    surfaces = [text[start:end] for start, end in spans]
-    if token_span_indices is None:
-        return surfaces
+        token_span_indices[token_index] = len(spans) - 1
 
     # 길이가 0인 형태소는 분석 순서상 다음 표면 구간에 결합합니다.
     next_span_index = None
@@ -60,8 +69,8 @@ def _split_by_spans(
         if span_index is not None:
             tags[span_index].append(token.tag)
     return [
-        (surface, '+'.join(tag_group))
-        for surface, tag_group in zip(surfaces, tags)
+        SplitToken(text[start:end], '+'.join(tag_group), start, end - start)
+        for (start, end), tag_group in zip(spans, tags)
     ]
 
 
@@ -1826,14 +1835,10 @@ Notes
         typos:Optional[Union[str, TypoTransformer]] = None,
         typo_cost_threshold:float = 2.5,
         override_config:Optional[KiwiConfig] = None,
-        return_tags:bool = False,
     ) -> Union[
-        List[str],
-        List[Tuple[str, str]],
-        Iterable[List[str]],
-        Iterable[List[Tuple[str, str]]],
-        Iterable[Tuple[List[str], str]],
-        Iterable[Tuple[List[Tuple[str, str]], str]],
+        List[SplitToken],
+        Iterable[List[SplitToken]],
+        Iterable[Tuple[List[SplitToken], str]],
     ]:
         '''Kiwi의 형태소 분석 경계에 맞춰 원문의 표면형을 나눕니다.
 
@@ -1841,7 +1846,8 @@ Notes
 Token 구간은 각각 나누어 반환합니다. Token이 없는 원문 구간은 결과에서
 제외하지만, 하나의 Token 구간 안에 포함된 공백은 원문 그대로 보존합니다.
 길이가 0인 Token은 분석 순서상 다음 표면형의 품사 태그에 결합하며, 다음
-표면형이 없을 때에는 이전 표면형에 결합합니다.
+표면형이 없을 때에는 이전 표면형에 결합합니다. 각 결과는 원문의 표면형,
+결합된 품사 태그, 원문 내 시작 위치와 길이를 담은 `SplitToken`입니다.
 
 Parameters
 ----------
@@ -1879,17 +1885,14 @@ override_config: KiwiConfig
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
 echo: bool
     text가 str의 Iterable이고 이 값이 True이면 분할 결과와 원문을 함께 반환합니다.
-return_tags: bool
-    True이면 `(표면형, 품사 태그)` 튜플의 목록을 반환합니다. 하나의 표면형에
-    여러 형태소가 대응하면 분석 결과 순서대로 품사 태그를 `+`로 연결합니다.
 
 Returns
 -------
-result: List[str] or List[Tuple[str, str]]
+result: List[SplitToken]
     text가 단일 str일 때의 분할 결과입니다.
-results: Iterable[List[str]] or Iterable[List[Tuple[str, str]]]
+results: Iterable[List[SplitToken]]
     text가 str의 Iterable일 때의 분할 결과입니다.
-results_with_echo: Iterable[Tuple[List[str], str]] or Iterable[Tuple[List[Tuple[str, str]], str]]
+results_with_echo: Iterable[Tuple[List[SplitToken], str]]
     text가 str의 Iterable이고 `echo=True`일 때의 분할 결과와 원문입니다.
 
 Notes
@@ -1897,11 +1900,10 @@ Notes
 
 ```python
 >>> kiwi.split('했다')
-['했', '다']
->>> kiwi.split('했다', return_tags=True)
-[('했', 'VV+EP'), ('다', 'EF')]
->>> kiwi.split('랠프 월도 에머슨', return_tags=True)
-[('랠프 월도 에머슨', 'NNP')]
+[SplitToken(form='했', tag='VV+EP', start=0, len=1),
+ SplitToken(form='다', tag='EF', start=1, len=1)]
+>>> kiwi.split('랠프 월도 에머슨')
+[SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
 ```
         '''
         result = self._tokenize(
@@ -1915,11 +1917,11 @@ Notes
             override_config=override_config,
         )
         if isinstance(text, str):
-            return _split_by_spans(text, result, return_tags)
+            return _split_by_spans(text, result)
 
         def _split_result(item):
             tokens, raw_input = item
-            parts = _split_by_spans(raw_input, tokens, return_tags)
+            parts = _split_by_spans(raw_input, tokens)
             return (parts, raw_input) if echo else parts
         return map(_split_result, result)
 

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -13,6 +13,58 @@ from kiwipiepy.utils import Stopwords
 from kiwipiepy.const import Match, Dialect
 from kiwipiepy.template import Template
 
+def _split_by_spans(
+    text: str,
+    tokens: List[Token],
+    return_tags: bool = False,
+) -> Union[List[str], List[Tuple[str, str]]]:
+    spans = []
+    token_span_indices = [None] * len(tokens) if return_tags else None
+    sorted_token_indices = sorted(
+        range(len(tokens)),
+        key=lambda i: (tokens[i].start, tokens[i].end),
+    )
+    for token_index in sorted_token_indices:
+        start, end = tokens[token_index].start, tokens[token_index].end
+        if start == end:
+            continue
+        if spans and start < spans[-1][1]:
+            spans[-1][1] = max(spans[-1][1], end)
+        else:
+            spans.append([start, end])
+        if token_span_indices is not None:
+            token_span_indices[token_index] = len(spans) - 1
+
+    surfaces = [text[start:end] for start, end in spans]
+    if token_span_indices is None:
+        return surfaces
+
+    # 길이가 0인 형태소는 분석 순서상 다음 표면 구간에 결합합니다.
+    next_span_index = None
+    for token_index in reversed(range(len(tokens))):
+        if token_span_indices[token_index] is not None:
+            next_span_index = token_span_indices[token_index]
+        elif tokens[token_index].start == tokens[token_index].end:
+            token_span_indices[token_index] = next_span_index
+
+    # 마지막에 놓인 길이 0 형태소는 앞선 표면 구간에 결합합니다.
+    previous_span_index = None
+    for token_index, token in enumerate(tokens):
+        if token_span_indices[token_index] is not None:
+            previous_span_index = token_span_indices[token_index]
+        elif token.start == token.end:
+            token_span_indices[token_index] = previous_span_index
+
+    tags = [[] for _ in spans]
+    for token, span_index in zip(tokens, token_span_indices):
+        if span_index is not None:
+            tags[span_index].append(token.tag)
+    return [
+        (surface, '+'.join(tag_group))
+        for surface, tag_group in zip(surfaces, tags)
+    ]
+
+
 class Sentence(NamedTuple):
     '''문장 분할 결과를 담기 위한 `namedtuple`입니다.'''
     text: str
@@ -1742,9 +1794,9 @@ Notes
 [Token(form='시곗바늘', tag='NNG', start=0, len=4)]
 ```
         '''
-        return self._tokenize(text, match_options, normalize_coda, 
+        return self._tokenize(text, match_options, normalize_coda,
                               z_coda, split_complex, compatible_jamo, saisiot,
-                              split_sents, stopwords, echo, 
+                              split_sents, stopwords, echo,
                               blocklist=blocklist, 
                               open_ending=open_ending,
                               allowed_dialects=allowed_dialects,
@@ -1755,6 +1807,121 @@ Notes
                               typo_cost_threshold=typo_cost_threshold,
                               override_config=override_config,
                               )
+
+    def split(self,
+        text:Union[str, Iterable[str]],
+        match_options:int = Match.ALL,
+        normalize_coda:bool = False,
+        z_coda:bool = True,
+        split_complex:bool = False,
+        compatible_jamo:bool = False,
+        saisiot:Optional[bool] = None,
+        echo:bool = False,
+        blocklist:Optional[Union[Iterable[str], MorphemeSet]] = None,
+        open_ending:bool = False,
+        allowed_dialects:Union[Dialect, str] = Dialect.STANDARD,
+        dialect_cost:float = 3.,
+        pretokenized:Optional[Union[Callable[[str], PretokenizedTokenList], PretokenizedTokenList]] = None,
+        oov_handling:Optional[str] = None,
+        typos:Optional[Union[str, TypoTransformer]] = None,
+        typo_cost_threshold:float = 2.5,
+        override_config:Optional[KiwiConfig] = None,
+        return_tags:bool = False,
+    ) -> Union[
+        List[str],
+        List[Tuple[str, str]],
+        Iterable[List[str]],
+        Iterable[List[Tuple[str, str]]],
+        Iterable[Tuple[List[str], str]],
+        Iterable[Tuple[List[Tuple[str, str]], str]],
+    ]:
+        '''Kiwi의 형태소 분석 경계에 맞춰 원문의 표면형을 나눕니다.
+
+서로 겹치는 Token 구간은 하나의 결과로 합치고, 겹치지 않고 이어지는
+Token 구간은 각각 나누어 반환합니다. Token이 없는 원문 구간은 결과에서
+제외하지만, 하나의 Token 구간 안에 포함된 공백은 원문 그대로 보존합니다.
+길이가 0인 Token은 분석 순서상 다음 표면형의 품사 태그에 결합하며, 다음
+표면형이 없을 때에는 이전 표면형에 결합합니다.
+
+Parameters
+----------
+text: Union[str, Iterable[str]]
+    분석할 문자열입니다. 단일 str 또는 str의 Iterable을 사용할 수 있습니다.
+match_options: kiwipiepy.const.Match
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+normalize_coda: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+z_coda: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+split_complex: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+compatible_jamo: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+saisiot: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+blocklist: Union[MorphemeSet, Iterable[str]]
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+open_ending: bool
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+allowed_dialects: Union[Dialect, str]
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+dialect_cost: float
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+pretokenized: Union[Callable[[str], PretokenizedTokenList], PretokenizedTokenList]
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+oov_handling: str
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+typos: Union[str, TypoTransformer]
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+typo_cost_threshold: float
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+override_config: KiwiConfig
+    `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+echo: bool
+    text가 str의 Iterable이고 이 값이 True이면 분할 결과와 원문을 함께 반환합니다.
+return_tags: bool
+    True이면 `(표면형, 품사 태그)` 튜플의 목록을 반환합니다. 하나의 표면형에
+    여러 형태소가 대응하면 분석 결과 순서대로 품사 태그를 `+`로 연결합니다.
+
+Returns
+-------
+result: List[str] or List[Tuple[str, str]]
+    text가 단일 str일 때의 분할 결과입니다.
+results: Iterable[List[str]] or Iterable[List[Tuple[str, str]]]
+    text가 str의 Iterable일 때의 분할 결과입니다.
+results_with_echo: Iterable[Tuple[List[str], str]] or Iterable[Tuple[List[Tuple[str, str]], str]]
+    text가 str의 Iterable이고 `echo=True`일 때의 분할 결과와 원문입니다.
+
+Notes
+-----
+
+```python
+>>> kiwi.split('했다')
+['했', '다']
+>>> kiwi.split('했다', return_tags=True)
+[('했', 'VV+EP'), ('다', 'EF')]
+>>> kiwi.split('랠프 월도 에머슨', return_tags=True)
+[('랠프 월도 에머슨', 'NNP')]
+```
+        '''
+        result = self._tokenize(
+            text, match_options, normalize_coda, z_coda, split_complex,
+            compatible_jamo, saisiot, False, None,
+            not isinstance(text, str), blocklist=blocklist,
+            open_ending=open_ending, allowed_dialects=allowed_dialects,
+            dialect_cost=dialect_cost, pretokenized=pretokenized,
+            oov_handling=oov_handling, typos=typos,
+            typo_cost_threshold=typo_cost_threshold,
+            override_config=override_config,
+        )
+        if isinstance(text, str):
+            return _split_by_spans(text, result, return_tags)
+
+        def _split_result(item):
+            tokens, raw_input = item
+            parts = _split_by_spans(raw_input, tokens, return_tags)
+            return (parts, raw_input) if echo else parts
+        return map(_split_result, result)
 
     def split_into_sents(self, 
         text:Union[str, Iterable[str]], 

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -1081,3 +1081,108 @@ def test_issue_216():
     tokens = kiwi.tokenize("테스트용\ufeff문자열입니다.")
     for token in tokens:
         assert token.form
+
+
+def test_split():
+    kiwi = Kiwi()
+    cases = {
+        '했다': ['했', '다'],
+        '하였다': ['하', '였', '다'],
+        '귀여워요': ['귀여워요'],
+        '걸어': ['걸', '어'],
+        '학생입니다': ['학생', '입니다'],
+        '도와': ['도', '와'],
+        '안녕하세요': ['안녕', '하', '세요'],
+    }
+    for text, expected in cases.items():
+        assert kiwi.split(text) == expected
+
+    assert kiwi.split('시곗바늘', saisiot=True) == ['시곗', '바늘']
+    assert kiwi.split(
+        'ABC',
+        pretokenized=[(0, 1, [PretokenizedToken('X', 'NNP', 0, 1)])],
+    ) == ['A', 'BC']
+
+    text = ' \t😀했다  안녕\n'
+    parts = kiwi.split(text)
+    assert parts == ['😀', '했', '다', '안녕']
+
+    assert kiwi.split('\u2800') == []
+    assert kiwi.split('A\u2800B') == ['A', 'B']
+
+    assert kiwi.split(
+        'A B',
+        pretokenized=[(0, 3, 'NNP')],
+    ) == ['A B']
+    assert kiwi.split('랠프 월도 에머슨') == ['랠프 월도 에머슨']
+
+    texts = ['했다', '귀여워요', '']
+    expected = [['했', '다'], ['귀여워요'], []]
+    assert list(kiwi.split(iter(texts))) == expected
+    assert list(kiwi.split(iter(texts), echo=True)) == list(zip(expected, texts))
+
+
+def test_split_with_tags():
+    kiwi = Kiwi()
+    cases = {
+        '했다': [('했', 'VV+EP'), ('다', 'EF')],
+        '시켰어요': [('시켰', 'VV+EP'), ('어요', 'EF')],
+        '학생입니다': [('학생', 'NNG'), ('입니다', 'VCP+EF')],
+        '거야': [('거', 'NNB'), ('야', 'VCP+EF')],
+        '랠프 월도 에머슨': [('랠프 월도 에머슨', 'NNP')],
+    }
+    for text, expected in cases.items():
+        assert kiwi.split(text, return_tags=True) == expected
+
+    assert kiwi.split('시곗바늘', saisiot=True, return_tags=True) == [
+        ('시곗', 'NNG+Z_SIOT'),
+        ('바늘', 'NNG'),
+    ]
+    assert kiwi.split('A\u2800B', return_tags=True) == [('A', 'SL'), ('B', 'SL')]
+
+    assert kiwi.split(
+        'A B',
+        pretokenized=[(0, 3, 'NNP')],
+        return_tags=True,
+    ) == [('A B', 'NNP')]
+
+    texts = ['했다', '']
+    expected = [[('했', 'VV+EP'), ('다', 'EF')], []]
+    assert list(kiwi.split(iter(texts), return_tags=True)) == expected
+    assert list(kiwi.split(iter(texts), return_tags=True, echo=True)) == list(zip(expected, texts))
+
+
+def test_split_by_spans_boundaries():
+    from types import SimpleNamespace
+    from kiwipiepy._wrap import _split_by_spans
+
+    def token(form, tag, start, end):
+        return SimpleNamespace(form=form, tag=tag, start=start, end=end)
+
+    # Token이 없는 구간은 버리되 하나의 Token span 내부 공백은 보존합니다.
+    assert _split_by_spans('A\u2800B', [
+        token('A', 'SL', 0, 1),
+        token('B', 'SL', 2, 3),
+    ]) == ['A', 'B']
+    assert _split_by_spans('A B', [token('A B', 'NNP', 0, 3)]) == ['A B']
+
+    # 태그 순서는 위치 정렬 순서가 아니라 형태소 분석 결과 순서를 따릅니다.
+    crossed = [
+        token('B', 'EP', 1, 2),
+        token('AB', 'VV', 0, 2),
+    ]
+    assert _split_by_spans('AB', crossed, return_tags=True) == [('AB', 'EP+VV')]
+
+    # 길이가 0인 Token은 다음 표면형에, 다음 표면형이 없으면 이전에 결합합니다.
+    assert _split_by_spans('AB', [
+        token('A', 'NNG', 0, 1),
+        token('이', 'VCP', 1, 1),
+        token('B', 'EF', 1, 2),
+    ], return_tags=True) == [('A', 'NNG'), ('B', 'VCP+EF')]
+    assert _split_by_spans('A', [
+        token('A', 'NNG', 0, 1),
+        token('만', 'JX', 1, 1),
+    ], return_tags=True) == [('A', 'NNG+JX')]
+    assert _split_by_spans('', [
+        token('이', 'VCP', 0, 0),
+    ], return_tags=True) == []

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -4,7 +4,7 @@ import re
 import tempfile
 import itertools
 
-from kiwipiepy import Kiwi, TypoTransformer, basic_typos, MorphemeSet, sw_tokenizer, PretokenizedToken, extract_substrings, Match
+from kiwipiepy import Kiwi, SplitToken, TypoTransformer, basic_typos, MorphemeSet, sw_tokenizer, PretokenizedToken, extract_substrings, Match
 from kiwipiepy.utils import Stopwords
 
 curpath = os.path.dirname(os.path.abspath(__file__))
@@ -1086,70 +1086,73 @@ def test_issue_216():
 def test_split():
     kiwi = Kiwi()
     cases = {
-        '했다': ['했', '다'],
-        '하였다': ['하', '였', '다'],
-        '귀여워요': ['귀여워요'],
-        '걸어': ['걸', '어'],
-        '학생입니다': ['학생', '입니다'],
-        '도와': ['도', '와'],
-        '안녕하세요': ['안녕', '하', '세요'],
+        '했다': [SplitToken('했', 'VV+EP', 0, 1), SplitToken('다', 'EF', 1, 1)],
+        '하였다': [
+            SplitToken('하', 'VV', 0, 1),
+            SplitToken('였', 'EP', 1, 1),
+            SplitToken('다', 'EF', 2, 1),
+        ],
+        '귀여워요': [SplitToken('귀여워요', 'VA-I+EF', 0, 4)],
+        '걸어': [SplitToken('걸', 'VV-I', 0, 1), SplitToken('어', 'EF', 1, 1)],
+        '학생입니다': [
+            SplitToken('학생', 'NNG', 0, 2),
+            SplitToken('입니다', 'VCP+EF', 2, 3),
+        ],
+        '도와': [SplitToken('도', 'VV-I', 0, 1), SplitToken('와', 'EF', 1, 1)],
+        '안녕하세요': [
+            SplitToken('안녕', 'NNG', 0, 2),
+            SplitToken('하', 'XSA', 2, 1),
+            SplitToken('세요', 'EF', 3, 2),
+        ],
     }
     for text, expected in cases.items():
-        assert kiwi.split(text) == expected
+        result = kiwi.split(text)
+        assert result == expected
+        assert all(part.form == text[part.start:part.start + part.len] for part in result)
 
-    assert kiwi.split('시곗바늘', saisiot=True) == ['시곗', '바늘']
+    assert kiwi.split('시곗바늘', saisiot=True) == [
+        SplitToken('시곗', 'NNG+Z_SIOT', 0, 2),
+        SplitToken('바늘', 'NNG', 2, 2),
+    ]
+    assert kiwi.split('시곗바늘', saisiot=False) == [
+        SplitToken('시곗바늘', 'NNG', 0, 4),
+    ]
     assert kiwi.split(
         'ABC',
         pretokenized=[(0, 1, [PretokenizedToken('X', 'NNP', 0, 1)])],
-    ) == ['A', 'BC']
+    ) == [SplitToken('A', 'NNP', 0, 1), SplitToken('BC', 'SL', 1, 2)]
 
     text = ' \t😀했다  안녕\n'
     parts = kiwi.split(text)
-    assert parts == ['😀', '했', '다', '안녕']
+    assert parts == [
+        SplitToken('😀', 'W_EMOJI', 2, 1),
+        SplitToken('했', 'XSV+EP', 3, 1),
+        SplitToken('다', 'EF', 4, 1),
+        SplitToken('안녕', 'IC', 7, 2),
+    ]
 
     assert kiwi.split('\u2800') == []
-    assert kiwi.split('A\u2800B') == ['A', 'B']
+    assert kiwi.split('A\u2800B') == [
+        SplitToken('A', 'SL', 0, 1),
+        SplitToken('B', 'SL', 2, 1),
+    ]
 
     assert kiwi.split(
         'A B',
         pretokenized=[(0, 3, 'NNP')],
-    ) == ['A B']
-    assert kiwi.split('랠프 월도 에머슨') == ['랠프 월도 에머슨']
+    ) == [SplitToken('A B', 'NNP', 0, 3)]
+    assert kiwi.split('랠프 월도 에머슨') == [
+        SplitToken('랠프 월도 에머슨', 'NNP', 0, 9),
+    ]
 
     texts = ['했다', '귀여워요', '']
-    expected = [['했', '다'], ['귀여워요'], []]
+    expected = [
+        [SplitToken('했', 'VV+EP', 0, 1), SplitToken('다', 'EF', 1, 1)],
+        [SplitToken('귀여워요', 'VA-I+EF', 0, 4)],
+        [],
+    ]
     assert list(kiwi.split(iter(texts))) == expected
     assert list(kiwi.split(iter(texts), echo=True)) == list(zip(expected, texts))
-
-
-def test_split_with_tags():
-    kiwi = Kiwi()
-    cases = {
-        '했다': [('했', 'VV+EP'), ('다', 'EF')],
-        '시켰어요': [('시켰', 'VV+EP'), ('어요', 'EF')],
-        '학생입니다': [('학생', 'NNG'), ('입니다', 'VCP+EF')],
-        '거야': [('거', 'NNB'), ('야', 'VCP+EF')],
-        '랠프 월도 에머슨': [('랠프 월도 에머슨', 'NNP')],
-    }
-    for text, expected in cases.items():
-        assert kiwi.split(text, return_tags=True) == expected
-
-    assert kiwi.split('시곗바늘', saisiot=True, return_tags=True) == [
-        ('시곗', 'NNG+Z_SIOT'),
-        ('바늘', 'NNG'),
-    ]
-    assert kiwi.split('A\u2800B', return_tags=True) == [('A', 'SL'), ('B', 'SL')]
-
-    assert kiwi.split(
-        'A B',
-        pretokenized=[(0, 3, 'NNP')],
-        return_tags=True,
-    ) == [('A B', 'NNP')]
-
-    texts = ['했다', '']
-    expected = [[('했', 'VV+EP'), ('다', 'EF')], []]
-    assert list(kiwi.split(iter(texts), return_tags=True)) == expected
-    assert list(kiwi.split(iter(texts), return_tags=True, echo=True)) == list(zip(expected, texts))
 
 
 def test_split_by_spans_boundaries():
@@ -1163,26 +1166,48 @@ def test_split_by_spans_boundaries():
     assert _split_by_spans('A\u2800B', [
         token('A', 'SL', 0, 1),
         token('B', 'SL', 2, 3),
-    ]) == ['A', 'B']
-    assert _split_by_spans('A B', [token('A B', 'NNP', 0, 3)]) == ['A B']
+    ]) == [SplitToken('A', 'SL', 0, 1), SplitToken('B', 'SL', 2, 1)]
+    assert _split_by_spans('A B', [token('A B', 'NNP', 0, 3)]) == [
+        SplitToken('A B', 'NNP', 0, 3),
+    ]
+    assert _split_by_spans('A B', [
+        token('B', 'TB', 2, 3),
+        token('A', 'TA', 0, 1),
+    ]) == [SplitToken('A', 'TA', 0, 1), SplitToken('B', 'TB', 2, 1)]
 
     # 태그 순서는 위치 정렬 순서가 아니라 형태소 분석 결과 순서를 따릅니다.
     crossed = [
         token('B', 'EP', 1, 2),
         token('AB', 'VV', 0, 2),
     ]
-    assert _split_by_spans('AB', crossed, return_tags=True) == [('AB', 'EP+VV')]
+    assert _split_by_spans('AB', crossed) == [SplitToken('AB', 'EP+VV', 0, 2)]
+
+    # 연쇄적으로 겹치는 구간은 합치되 맞닿기만 한 구간은 따로 둡니다.
+    assert _split_by_spans('ABCDE', [
+        token('BC', 'EP', 1, 3),
+        token('AB', 'VV', 0, 2),
+        token('D', 'NNG', 3, 4),
+        token('E', 'JX', 4, 5),
+    ]) == [
+        SplitToken('ABC', 'EP+VV', 0, 3),
+        SplitToken('D', 'NNG', 3, 1),
+        SplitToken('E', 'JX', 4, 1),
+    ]
 
     # 길이가 0인 Token은 다음 표면형에, 다음 표면형이 없으면 이전에 결합합니다.
+    assert _split_by_spans('A', [
+        token('만', 'JX', 0, 0),
+        token('A', 'NNG', 0, 1),
+    ]) == [SplitToken('A', 'JX+NNG', 0, 1)]
     assert _split_by_spans('AB', [
         token('A', 'NNG', 0, 1),
         token('이', 'VCP', 1, 1),
         token('B', 'EF', 1, 2),
-    ], return_tags=True) == [('A', 'NNG'), ('B', 'VCP+EF')]
+    ]) == [SplitToken('A', 'NNG', 0, 1), SplitToken('B', 'VCP+EF', 1, 1)]
     assert _split_by_spans('A', [
         token('A', 'NNG', 0, 1),
         token('만', 'JX', 1, 1),
-    ], return_tags=True) == [('A', 'NNG+JX')]
+    ]) == [SplitToken('A', 'NNG+JX', 0, 1)]
     assert _split_by_spans('', [
         token('이', 'VCP', 0, 0),
-    ], return_tags=True) == []
+    ]) == []


### PR DESCRIPTION
## 제안 배경

`Kiwi.tokenize()`의 형태소 분석 경계는 사용하되, 형태소의 정규화된 `form` 대신 원문 표면형을 그대로 보존한 분할 결과가 필요한 경우가 있습니다.

예를 들어 `했다`를 `Kiwi.tokenize()`로 분석하면 `하/VV`, `었/EP`, `다/EF`가 되지만, 원문에서 두 형태소가 같은 한 글자를 가리키므로 표면형 기준으로는 `했/VV+EP`, `다/EF`가 됩니다.

## 변경 내용

- `Kiwi.tokenize()`의 옵션이 아니라 별도 메서드 `Kiwi.split()`으로 구현했습니다.
- 반환형은 항상 `SplitToken` 데이터 클래스입니다.
  - `form`: 원문에서 잘라낸 표면형
  - `tag`: 같은 표면형에 대응하는 품사 태그를 분석 결과 순서대로 `+`로 연결한 값
  - `start`: 원문 내 시작 위치
  - `len`: 원문에서 차지하는 길이
- 겹치는 Token 구간은 하나로 합치고, 맞닿기만 한 구간은 별도로 유지합니다.
- Token이 없는 원문 구간과 공백은 제외하되, 하나의 Token 구간 내부에 포함된 공백은 보존합니다.
- 길이가 0인 형태소는 분석 순서상 다음 표면형에 결합하고, 다음 표면형이 없으면 이전 표면형에 결합합니다.
- `tokenize()`와 같은 분석 옵션 및 여러 문자열 입력과 `echo=True`를 지원합니다.

```python
>>> kiwi.split("했다")
[SplitToken(form='했', tag='VV+EP', start=0, len=1),
 SplitToken(form='다', tag='EF', start=1, len=1)]

>>> kiwi.split("랠프 월도 에머슨")
[SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
```

## 테스트

다음 동작을 테스트로 검증했습니다.

- 활용·축약 표현의 원문 표면형과 결합 태그
- `saisiot=True/False` 및 `pretokenized`
- 겹침·연쇄 겹침·인접 구간의 경계
- 선두·중간·후미의 길이 0 형태소
- Token이 없는 구간 제거와 Token 내부 공백 보존
- 입력 Token 순서와 무관한 원문 위치순 출력
- 여러 문자열 입력과 `echo=True`
- 모든 결과에서 `part.form == text[part.start:part.start + part.len]`

로컬 검증 결과:

- 주 테스트: 68 passed, 1 deselected
  - 제외한 테스트는 현재 소스와 로컬 설치 네이티브 확장 버전 차이로 충돌하는 `test_pretokenized_ranges_reject_empty_and_overflow`입니다.
- nogil 안전성: 2 passed
- Transformers 연동: 9 passed
- 저장소 테스트·벤치마크 텍스트 3,985줄, 원본 Token 437,971개, `SplitToken` 425,332개에 대해 원문 정렬·순서·복원 불변식 통과

## 성능

A안의 태그 포함 튜플 반환과 B안의 `SplitToken` 반환을 동일 입력으로 7회 측정한 전체 처리 시간 중앙값입니다.

| 입력 | workers | A안 태그 포함 | B안 `SplitToken` | 차이 |
|---|---:|---:|---:|---:|
| 저장소 텍스트 3,985줄 | 1 | 3.006s | 3.013s | +0.22% |
| 저장소 텍스트 3,985줄 | 6 | 0.592s | 0.600s | +1.29% |

구조화 객체 생성 비용은 생기지만, 형태소 분석을 포함한 전체 처리 시간에서는 약 0.2~1.3%의 차이였습니다.
