### PR TITLE
Kiwi.split 문서 및 테스트 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ kiwi을 생성하고, 사용자 사전에 단어를 추가하는 작업이 완�
 ```python
 Kiwi.tokenize(text, match_option, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
 Kiwi.analyze(text, top_n, match_option, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
-Kiwi.split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)
+Kiwi.split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, open_ending=False, allowed_dialects='standard', dialect_cost=3.0, pretokenized=None, oov_handling=None, typos=None, typo_cost_threshold=2.5, override_config=None)
 Kiwi.split_into_sents(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, return_tokens=False)
 Kiwi.glue(text_chunks, insert_new_lines=None, return_space_insertions=False)
 Kiwi.space(text, reset_whitespace=False)
@@ -856,7 +856,7 @@ SystemError: <built-in function next> returned a result with an error set
 <hr>
 
 <details>
-<summary><code>split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, allowed_dialects='standard', dialect_cost=3.0, oov_handling=None, typos=None, typo_cost_threshold=2.5)</code></summary>
+<summary><code>split(text, match_options=Match.ALL, normalize_coda=False, z_coda=True, split_complex=False, compatible_jamo=False, saisiot=None, echo=False, blocklist=None, open_ending=False, allowed_dialects='standard', dialect_cost=3.0, pretokenized=None, oov_handling=None, typos=None, typo_cost_threshold=2.5, override_config=None)</code></summary>
 
 형태소 분석 경계에 맞춰 원문의 표면형을 나눕니다. 각 결과는 표면형과 품사 태그, 원문 내 시작 위치와 길이를 담은 `SplitToken`입니다. 하나의 표면형에 여러 형태소가 대응하면 품사 태그를 분석 결과 순서대로 `+`로 연결합니다.
 
@@ -864,6 +864,8 @@ SystemError: <built-in function next> returned a result with an error set
 >> kiwi.split('했다')
 [SplitToken(form='했', tag='VV+EP', start=0, len=1),
  SplitToken(form='다', tag='EF', start=1, len=1)]
+>> [part.form for part in kiwi.split('했다')]
+['했', '다']
 >> kiwi.split('랠프 월도 에머슨')
 [SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
 ```

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -42,6 +42,7 @@ def _split_by_spans(
         start, end = tokens[token_index].start, tokens[token_index].end
         if start == end:
             continue
+        # 겹치는 구간은 합치고, 맞닿기만 한 구간은 따로 둡니다.
         if spans and start < spans[-1][1]:
             spans[-1][1] = max(spans[-1][1], end)
         else:
@@ -56,7 +57,7 @@ def _split_by_spans(
         elif tokens[token_index].start == tokens[token_index].end:
             token_span_indices[token_index] = next_span_index
 
-    # 마지막에 놓인 길이 0 형태소는 앞선 표면 구간에 결합합니다.
+    # 뒤에 표면 구간이 없는 길이 0 형태소는 앞선 표면 구간에 결합합니다.
     previous_span_index = None
     for token_index, token in enumerate(tokens):
         if token_span_indices[token_index] is not None:
@@ -1863,8 +1864,10 @@ split_complex: bool
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
 compatible_jamo: bool
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
-saisiot: bool
+saisiot: Optional[bool]
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
+echo: bool
+    text가 str의 Iterable이고 이 값이 True이면 분할 결과와 원문을 함께 반환합니다.
 blocklist: Union[MorphemeSet, Iterable[str]]
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
 open_ending: bool
@@ -1883,8 +1886,6 @@ typo_cost_threshold: float
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
 override_config: KiwiConfig
     `Kiwi.tokenize`에서와 동일한 역할을 수행합니다.
-echo: bool
-    text가 str의 Iterable이고 이 값이 True이면 분할 결과와 원문을 함께 반환합니다.
 
 Returns
 -------
@@ -1902,10 +1903,13 @@ Notes
 >>> kiwi.split('했다')
 [SplitToken(form='했', tag='VV+EP', start=0, len=1),
  SplitToken(form='다', tag='EF', start=1, len=1)]
+>>> [part.form for part in kiwi.split('했다')]
+['했', '다']
 >>> kiwi.split('랠프 월도 에머슨')
 [SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
 ```
         '''
+        # iterable 입력의 각 분석 결과를 원문과 다시 대응시키기 위해 내부 echo를 켭니다.
         result = self._tokenize(
             text, match_options, normalize_coda, z_coda, split_complex,
             compatible_jamo, saisiot, False, None,

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -3,6 +3,7 @@ import sys
 import re
 import tempfile
 import itertools
+import pickle
 
 from kiwipiepy import Kiwi, SplitToken, TypoTransformer, basic_typos, MorphemeSet, sw_tokenizer, PretokenizedToken, extract_substrings, Match
 from kiwipiepy.utils import Stopwords
@@ -1153,6 +1154,38 @@ def test_split():
     ]
     assert list(kiwi.split(iter(texts))) == expected
     assert list(kiwi.split(iter(texts), echo=True)) == list(zip(expected, texts))
+
+    pretokenized_inputs = []
+
+    def pretokenize(text):
+        pretokenized_inputs.append(text)
+        return [(0, len(text), 'NNP')]
+
+    texts = ['A B', 'CD']
+    expected = [
+        [SplitToken('A B', 'NNP', 0, 3)],
+        [SplitToken('CD', 'NNP', 0, 2)],
+    ]
+    assert list(kiwi.split(iter(texts), pretokenized=pretokenize)) == expected
+    assert pretokenized_inputs == texts
+
+    pretokenized_inputs.clear()
+    assert list(kiwi.split(
+        iter(texts), pretokenized=pretokenize, echo=True,
+    )) == list(zip(expected, texts))
+    assert pretokenized_inputs == texts
+
+
+def test_split_token():
+    token = SplitToken('했', 'VV+EP', 0, 1)
+
+    assert token.form == '했'
+    assert token.tag == 'VV+EP'
+    assert token.start == 0
+    assert token.len == 1
+    assert token == SplitToken('했', 'VV+EP', 0, 1)
+    assert SplitToken.__module__ == 'kiwipiepy'
+    assert pickle.loads(pickle.dumps(token)) == token
 
 
 def test_split_by_spans_boundaries():


### PR DESCRIPTION
안녕하세요! #227을 올린 뒤 추가로 다듬을 부분이 있어 작업 중이었는데, 그사이 먼저 머지해주셨네요 ㅜㅜ

아래는 큰 변경 사항 없이, #227에 추가해 마무리하려던 문서 및 테스트 보완입니다. 
이전 pr 머지해주셔서 감사하고, 확인 후 추가로 머지해주시면 감사하겠습니다!

## 변경 내용

- README와 docstring의 `Kiwi.split` 인자 및 타입 표기를 실제 함수 서명과 일치시켰습니다.
- 문자열 목록이 필요한 경우를 위한 `part.form` 사용 예시를 추가했습니다.
- iterable 입력에서 callable `pretokenized`와 `echo=True`를 함께 사용하는 경우를 테스트했습니다.
- `SplitToken`의 필드, 동등성, 공개 모듈 경로 및 pickle 호환성을 테스트했습니다.
- 일부 동작을 설명하는 주석을 보완했습니다.

실행 로직 변경은 없습니다.

## 검증

- 주 테스트 및 nogil 안전성 테스트: 72 passed
- Transformers 연동 테스트: 9 passed
- pdoc3 문서 생성 성공