### PR TITLE
`Kiwi.split`를 `Kiwi.split_into_forms`로 변경

### DIFF
--- a/kiwipiepy/__init__.py
+++ b/kiwipiepy/__init__.py
@@ -6,7 +6,7 @@ from kiwipiepy._version import __version__
 from kiwipiepy._wrap import (
     Kiwi, 
     KiwiConfig,
-    SplitToken,
+    SplitForm,
     Sentence, 
     TypoTransformer, 
     TypoDefinition, 
@@ -30,7 +30,7 @@ from kiwipiepy.default_typo_transformer import (
 )
 
 Kiwi.__module__ = 'kiwipiepy'
-SplitToken.__module__ = 'kiwipiepy'
+SplitForm.__module__ = 'kiwipiepy'
 Sentence.__module__ = 'kiwipiepy'
 TypoTransformer.__module__ = 'kiwipiepy'
 TypoDefinition.__module__ = 'kiwipiepy'

--- a/kiwipiepy/_wrap.py
+++ b/kiwipiepy/_wrap.py
@@ -1,7 +1,7 @@
 import re
 from functools import partial
 from typing import Callable, List, Dict, Optional, Tuple, Union, Iterable, NamedTuple, NewType, Any
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import itertools
 import warnings
 
@@ -15,23 +15,32 @@ from kiwipiepy.template import Template
 
 
 @dataclass
-class SplitToken:
-    '''원문의 표면형을 보존한 분할 결과를 담는 데이터 클래스입니다.
+class SplitForm:
+    '''.. versionadded:: 0.24.0
 
-    `form`은 원문에서 잘라낸 표면형이며, `tag`는 해당 구간에 대응하는
-    형태소들의 품사 태그를 분석 결과 순서대로 `+`로 연결한 값입니다.
-    `start`와 `len`은 입력 텍스트 내 위치와 길이를 문자 단위로 나타냅니다.
+`Kiwi.split_into_forms`의 결과로, 원문의 표면형을 보존한 분할 단위를 담는 데이터 클래스입니다.
     '''
     form: str
+    '''원문에서 잘라낸 표면형'''
     tag: str
+    '''이 구간에 대응하는 형태소들의 품사 태그를 분석 결과 순서대로 `+`로 연결한 값'''
     start: int
-    len: int
+    '''전체 텍스트 내에서 이 구간이 시작하는 위치 (문자 단위)'''
+    end: int
+    '''전체 텍스트 내에서 이 구간이 끝나는 위치 (문자 단위)'''
+    tokens: List[Token] = field(default_factory=list, repr=False, compare=False)
+    '''이 구간에 대응하는 형태소 `Token`의 목록'''
+
+    @property
+    def len(self) -> int:
+        '''이 구간의 길이 (문자 단위)'''
+        return self.end - self.start
 
 
 def _split_by_spans(
     text: str,
     tokens: List[Token],
-) -> List[SplitToken]:
+) -> List[SplitForm]:
     spans = []
     token_span_indices = [None] * len(tokens)
     sorted_token_indices = sorted(
@@ -65,32 +74,117 @@ def _split_by_spans(
         elif token.start == token.end:
             token_span_indices[token_index] = previous_span_index
 
-    tags = [[] for _ in spans]
+    span_tokens = [[] for _ in spans]
     for token, span_index in zip(tokens, token_span_indices):
         if span_index is not None:
-            tags[span_index].append(token.tag)
+            span_tokens[span_index].append(token)
     return [
-        SplitToken(text[start:end], '+'.join(tag_group), start, end - start)
-        for (start, end), tag_group in zip(spans, tags)
+        SplitForm(
+            text[start:end],
+            '+'.join(token.tag for token in token_group),
+            start,
+            end,
+            token_group,
+        )
+        for (start, end), token_group in zip(spans, span_tokens)
     ]
 
 
-class Sentence(NamedTuple):
-    '''문장 분할 결과를 담기 위한 `namedtuple`입니다.'''
-    text: str
-    start: int
-    end: int
-    tokens: Optional[List[Token]]
-    subs: Optional[List['Sentence']]
+_SENTENCE_FIELDS = ('text', 'start', 'end', 'tokens', 'subs')
 
-Sentence.text.__doc__ = '분할된 문장의 텍스트'
-Sentence.start.__doc__ = '전체 텍스트 내에서 분할된 문장이 시작하는 위치 (문자 단위)'
-Sentence.end.__doc__ = '전체 텍스트 내에서 분할된 문장이 끝나는 위치 (문자 단위)'
-Sentence.tokens.__doc__ = '분할된 문장의 형태소 분석 결과'
-Sentence.subs.__doc__ = '''.. versionadded:: 0.14.0
+def _warn_sentence_as_tuple(usage: str):
+    warnings.warn(
+        f"Using `Sentence` as a tuple ({usage}) is deprecated since 0.24.0. "
+        f"Please access its fields by name (`{'`, `'.join(_SENTENCE_FIELDS)}`) instead. "
+        "Tuple compatibility will be removed in a future version.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+class _DeprecatedFields:
+    def __get__(self, obj, objtype=None):
+        _warn_sentence_as_tuple('_fields')
+        return _SENTENCE_FIELDS
+
+@dataclass(frozen=True, eq=False)
+class Sentence:
+    '''문장 분할 결과를 담기 위한 데이터 클래스입니다.
+
+    .. versionchanged:: 0.24.0
+
+        `namedtuple`에서 데이터 클래스로 변경되었습니다. 언패킹, 인덱싱 등
+        튜플처럼 다루는 사용법은 당분간 `FutureWarning`과 함께 계속
+        동작하지만, 향후 버전에서 제거될 예정이므로 속성 이름으로 접근하는
+        방식으로 옮겨주세요.
+    '''
+    text: str
+    '''분할된 문장의 텍스트'''
+    start: int
+    '''전체 텍스트 내에서 분할된 문장이 시작하는 위치 (문자 단위)'''
+    end: int
+    '''전체 텍스트 내에서 분할된 문장이 끝나는 위치 (문자 단위)'''
+    tokens: Optional[List[Token]]
+    '''분할된 문장의 형태소 분석 결과'''
+    subs: Optional[List['Sentence']]
+    '''.. versionadded:: 0.14.0
 
 현 문장 내에 포함된 안긴 문장의 목록
 '''
+
+    @property
+    def len(self) -> int:
+        '''.. versionadded:: 0.24.0
+
+분할된 문장의 길이 (문자 단위). 튜플 호환을 위해 남아있는 `len(sentence)`와는
+다른 값이므로 주의해주세요. `len(sentence)`는 필드의 개수를 돌려줍니다.
+'''
+        return self.end - self.start
+
+    # 이하는 `namedtuple`이던 시절과의 하위호환을 위한 것으로, 향후 제거됩니다.
+    _fields = _DeprecatedFields()
+
+    def _astuple(self) -> tuple:
+        return (self.text, self.start, self.end, self.tokens, self.subs)
+
+    def __iter__(self):
+        _warn_sentence_as_tuple('unpacking or iteration')
+        return iter(self._astuple())
+
+    def __getitem__(self, index):
+        _warn_sentence_as_tuple('indexing')
+        return self._astuple()[index]
+
+    def __len__(self) -> int:
+        _warn_sentence_as_tuple('len()')
+        return len(_SENTENCE_FIELDS)
+
+    def __bool__(self) -> bool:
+        # __len__이 있으면 truth 판정에까지 경고가 새어나오므로 따로 정의.
+        return True
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Sentence):
+            return self._astuple() == other._astuple()
+        if isinstance(other, tuple):
+            _warn_sentence_as_tuple('comparison with a tuple')
+            return self._astuple() == other
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._astuple())
+
+    def _asdict(self) -> Dict[str, Any]:
+        _warn_sentence_as_tuple('_asdict()')
+        return dict(zip(_SENTENCE_FIELDS, self._astuple()))
+
+    def _replace(self, **kwargs) -> 'Sentence':
+        _warn_sentence_as_tuple('_replace()')
+        unknown = set(kwargs) - set(_SENTENCE_FIELDS)
+        if unknown:
+            raise ValueError(f'Got unexpected field names: {sorted(unknown)!r}')
+        values = dict(zip(_SENTENCE_FIELDS, self._astuple()))
+        values.update(kwargs)
+        return Sentence(**values)
 
 POSTag = NewType('POSTag', str)
 SenseId = NewType('SenseId', int)
@@ -283,7 +377,7 @@ def _convert_oov_handling(oov_handling: Union[str, int]) -> Match:
     elif oov_handling in (Match.OOV_RULE_ONLY, Match.OOV_CHR_MODEL, Match.OOV_CHR_FREQ_MODEL, Match.OOV_CHR_FREQ_BRANCH_MODEL, Match.OOV_TOTAL_CONSISTENCY, Match.OOV_CHR_FREQ_MODEL | Match.OOV_TOTAL_CONSISTENCY):
         return oov_handling
     else:
-        raise ValueError(f"Unknown oov_handling option: {oov_handling}. Should be one of (None, 'rule', 'chr', 'chr_freq', 'chr_freq_branch').")
+        raise ValueError(f"Unknown oov_handling option: {oov_handling}. Should be one of (None, 'rule', 'chr', 'chr_freq', 'chr_freq_branch', 'chr_freq_consistency').")
 
 class TypoTransformer(_TypoTransformer):
     '''.. versionadded:: 0.13.0
@@ -1818,7 +1912,7 @@ Notes
                               override_config=override_config,
                               )
 
-    def split(self,
+    def split_into_forms(self,
         text:Union[str, Iterable[str]],
         match_options:int = Match.ALL,
         normalize_coda:bool = False,
@@ -1837,9 +1931,9 @@ Notes
         typo_cost_threshold:float = 2.5,
         override_config:Optional[KiwiConfig] = None,
     ) -> Union[
-        List[SplitToken],
-        Iterable[List[SplitToken]],
-        Iterable[Tuple[List[SplitToken], str]],
+        List[SplitForm],
+        Iterable[List[SplitForm]],
+        Iterable[Tuple[List[SplitForm], str]],
     ]:
         '''Kiwi의 형태소 분석 경계에 맞춰 원문의 표면형을 나눕니다.
 
@@ -1847,8 +1941,10 @@ Notes
 Token 구간은 각각 나누어 반환합니다. Token이 없는 원문 구간은 결과에서
 제외하지만, 하나의 Token 구간 안에 포함된 공백은 원문 그대로 보존합니다.
 길이가 0인 Token은 분석 순서상 다음 표면형의 품사 태그에 결합하며, 다음
-표면형이 없을 때에는 이전 표면형에 결합합니다. 각 결과는 원문의 표면형,
-결합된 품사 태그, 원문 내 시작 위치와 길이를 담은 `SplitToken`입니다.
+표면형이 없을 때에는 이전 표면형에 결합합니다. 
+분할된 결과는 `SplitForm` data class로 반환됩니다. 이 클래스에는 원문의 표면형,
+결합된 품사 태그, 원문 내 시작/끝 위치, 그리고 해당 구간에 대응하는
+형태소 `Token`의 목록이 포함되어 있습니다.
 
 Parameters
 ----------
@@ -1889,24 +1985,31 @@ override_config: KiwiConfig
 
 Returns
 -------
-result: List[SplitToken]
+result: List[SplitForm]
     text가 단일 str일 때의 분할 결과입니다.
-results: Iterable[List[SplitToken]]
+results: Iterable[List[SplitForm]]
     text가 str의 Iterable일 때의 분할 결과입니다.
-results_with_echo: Iterable[Tuple[List[SplitToken], str]]
+results_with_echo: Iterable[Tuple[List[SplitForm], str]]
     text가 str의 Iterable이고 `echo=True`일 때의 분할 결과와 원문입니다.
 
 Notes
 -----
 
 ```python
->>> kiwi.split('했다')
-[SplitToken(form='했', tag='VV+EP', start=0, len=1),
- SplitToken(form='다', tag='EF', start=1, len=1)]
->>> [part.form for part in kiwi.split('했다')]
+>>> kiwi.split_into_forms('했다')
+[SplitForm(form='했', tag='VV+EP', start=0, end=1),
+ SplitForm(form='다', tag='EF', start=1, end=2)]
+>>> [part.form for part in kiwi.split_into_forms('했다')]
 ['했', '다']
->>> kiwi.split('랠프 월도 에머슨')
-[SplitToken(form='랠프 월도 에머슨', tag='NNP', start=0, len=9)]
+>>> kiwi.split_into_forms('랠프 월도 에머슨')
+[SplitForm(form='랠프 월도 에머슨', tag='NNP', start=0, end=9)]
+```
+
+`tokens` 필드에는 각 표면형에 대응하는 형태소 분석 결과가 그대로 담겨 있습니다.
+
+```python
+>>> kiwi.split_into_forms('했다')[0].tokens
+[Token(form='하', tag='VV', start=0, len=1), Token(form='었', tag='EP', start=0, len=1)]
 ```
         '''
         # iterable 입력의 각 분석 결과를 원문과 다시 대응시키기 위해 내부 echo를 켭니다.

--- a/src/KiwiPy.cpp
+++ b/src/KiwiPy.cpp
@@ -3289,8 +3289,6 @@ void pyTrainBpeTokenizer(
 			py::UniqueObj item{ PyIter_Next(iter.get()) };
 			if (!item)
 			{
-				// 반복자가 도중에 예외를 던진 경우를 입력 소진으로 오인하면
-				// 잘린 데이터로 학습이 완료되어버리므로 구분해서 전파한다.
 				if (PyErr_Occurred()) throw py::ExcPropagation{};
 				else return string{};
 			}

--- a/test/test_kiwipiepy.py
+++ b/test/test_kiwipiepy.py
@@ -5,7 +5,7 @@ import tempfile
 import itertools
 import pickle
 
-from kiwipiepy import Kiwi, SplitToken, TypoTransformer, basic_typos, MorphemeSet, sw_tokenizer, PretokenizedToken, extract_substrings, Match
+from kiwipiepy import Kiwi, SplitForm, Sentence, TypoTransformer, basic_typos, MorphemeSet, sw_tokenizer, PretokenizedToken, extract_substrings, Match
 from kiwipiepy.utils import Stopwords
 
 curpath = os.path.dirname(os.path.abspath(__file__))
@@ -1084,76 +1084,76 @@ def test_issue_216():
         assert token.form
 
 
-def test_split():
+def test_split_into_forms():
     kiwi = Kiwi()
     cases = {
-        '했다': [SplitToken('했', 'VV+EP', 0, 1), SplitToken('다', 'EF', 1, 1)],
+        '했다': [SplitForm('했', 'VV+EP', 0, 1), SplitForm('다', 'EF', 1, 2)],
         '하였다': [
-            SplitToken('하', 'VV', 0, 1),
-            SplitToken('였', 'EP', 1, 1),
-            SplitToken('다', 'EF', 2, 1),
+            SplitForm('하', 'VV', 0, 1),
+            SplitForm('였', 'EP', 1, 2),
+            SplitForm('다', 'EF', 2, 3),
         ],
-        '귀여워요': [SplitToken('귀여워요', 'VA-I+EF', 0, 4)],
-        '걸어': [SplitToken('걸', 'VV-I', 0, 1), SplitToken('어', 'EF', 1, 1)],
+        '귀여워요': [SplitForm('귀여워요', 'VA-I+EF', 0, 4)],
+        '걸어': [SplitForm('걸', 'VV-I', 0, 1), SplitForm('어', 'EF', 1, 2)],
         '학생입니다': [
-            SplitToken('학생', 'NNG', 0, 2),
-            SplitToken('입니다', 'VCP+EF', 2, 3),
+            SplitForm('학생', 'NNG', 0, 2),
+            SplitForm('입니다', 'VCP+EF', 2, 5),
         ],
-        '도와': [SplitToken('도', 'VV-I', 0, 1), SplitToken('와', 'EF', 1, 1)],
+        '도와': [SplitForm('도', 'VV-I', 0, 1), SplitForm('와', 'EF', 1, 2)],
         '안녕하세요': [
-            SplitToken('안녕', 'NNG', 0, 2),
-            SplitToken('하', 'XSA', 2, 1),
-            SplitToken('세요', 'EF', 3, 2),
+            SplitForm('안녕', 'NNG', 0, 2),
+            SplitForm('하', 'XSA', 2, 3),
+            SplitForm('세요', 'EF', 3, 5),
         ],
     }
     for text, expected in cases.items():
-        result = kiwi.split(text)
+        result = kiwi.split_into_forms(text)
         assert result == expected
-        assert all(part.form == text[part.start:part.start + part.len] for part in result)
+        assert all(part.form == text[part.start:part.end] for part in result)
 
-    assert kiwi.split('시곗바늘', saisiot=True) == [
-        SplitToken('시곗', 'NNG+Z_SIOT', 0, 2),
-        SplitToken('바늘', 'NNG', 2, 2),
+    assert kiwi.split_into_forms('시곗바늘', saisiot=True) == [
+        SplitForm('시곗', 'NNG+Z_SIOT', 0, 2),
+        SplitForm('바늘', 'NNG', 2, 4),
     ]
-    assert kiwi.split('시곗바늘', saisiot=False) == [
-        SplitToken('시곗바늘', 'NNG', 0, 4),
+    assert kiwi.split_into_forms('시곗바늘', saisiot=False) == [
+        SplitForm('시곗바늘', 'NNG', 0, 4),
     ]
-    assert kiwi.split(
+    assert kiwi.split_into_forms(
         'ABC',
         pretokenized=[(0, 1, [PretokenizedToken('X', 'NNP', 0, 1)])],
-    ) == [SplitToken('A', 'NNP', 0, 1), SplitToken('BC', 'SL', 1, 2)]
+    ) == [SplitForm('A', 'NNP', 0, 1), SplitForm('BC', 'SL', 1, 3)]
 
     text = ' \t😀했다  안녕\n'
-    parts = kiwi.split(text)
+    parts = kiwi.split_into_forms(text)
     assert parts == [
-        SplitToken('😀', 'W_EMOJI', 2, 1),
-        SplitToken('했', 'XSV+EP', 3, 1),
-        SplitToken('다', 'EF', 4, 1),
-        SplitToken('안녕', 'IC', 7, 2),
+        SplitForm('😀', 'W_EMOJI', 2, 3),
+        SplitForm('했', 'XSV+EP', 3, 4),
+        SplitForm('다', 'EF', 4, 5),
+        SplitForm('안녕', 'IC', 7, 9),
     ]
 
-    assert kiwi.split('\u2800') == []
-    assert kiwi.split('A\u2800B') == [
-        SplitToken('A', 'SL', 0, 1),
-        SplitToken('B', 'SL', 2, 1),
+    assert kiwi.split_into_forms('\u2800') == []
+    assert kiwi.split_into_forms('A\u2800B') == [
+        SplitForm('A', 'SL', 0, 1),
+        SplitForm('B', 'SL', 2, 3),
     ]
 
-    assert kiwi.split(
+    assert kiwi.split_into_forms(
         'A B',
         pretokenized=[(0, 3, 'NNP')],
-    ) == [SplitToken('A B', 'NNP', 0, 3)]
-    assert kiwi.split('랠프 월도 에머슨') == [
-        SplitToken('랠프 월도 에머슨', 'NNP', 0, 9),
+    ) == [SplitForm('A B', 'NNP', 0, 3)]
+    assert kiwi.split_into_forms('랠프 월도 에머슨') == [
+        SplitForm('랠프 월도 에머슨', 'NNP', 0, 9),
     ]
 
     texts = ['했다', '귀여워요', '']
     expected = [
-        [SplitToken('했', 'VV+EP', 0, 1), SplitToken('다', 'EF', 1, 1)],
-        [SplitToken('귀여워요', 'VA-I+EF', 0, 4)],
+        [SplitForm('했', 'VV+EP', 0, 1), SplitForm('다', 'EF', 1, 2)],
+        [SplitForm('귀여워요', 'VA-I+EF', 0, 4)],
         [],
     ]
-    assert list(kiwi.split(iter(texts))) == expected
-    assert list(kiwi.split(iter(texts), echo=True)) == list(zip(expected, texts))
+    assert list(kiwi.split_into_forms(iter(texts))) == expected
+    assert list(kiwi.split_into_forms(iter(texts), echo=True)) == list(zip(expected, texts))
 
     pretokenized_inputs = []
 
@@ -1163,29 +1163,58 @@ def test_split():
 
     texts = ['A B', 'CD']
     expected = [
-        [SplitToken('A B', 'NNP', 0, 3)],
-        [SplitToken('CD', 'NNP', 0, 2)],
+        [SplitForm('A B', 'NNP', 0, 3)],
+        [SplitForm('CD', 'NNP', 0, 2)],
     ]
-    assert list(kiwi.split(iter(texts), pretokenized=pretokenize)) == expected
+    assert list(kiwi.split_into_forms(iter(texts), pretokenized=pretokenize)) == expected
     assert pretokenized_inputs == texts
 
     pretokenized_inputs.clear()
-    assert list(kiwi.split(
+    assert list(kiwi.split_into_forms(
         iter(texts), pretokenized=pretokenize, echo=True,
     )) == list(zip(expected, texts))
     assert pretokenized_inputs == texts
 
 
-def test_split_token():
-    token = SplitToken('했', 'VV+EP', 0, 1)
+def test_split_form():
+    token = SplitForm('했', 'VV+EP', 0, 1)
 
     assert token.form == '했'
     assert token.tag == 'VV+EP'
     assert token.start == 0
-    assert token.len == 1
-    assert token == SplitToken('했', 'VV+EP', 0, 1)
-    assert SplitToken.__module__ == 'kiwipiepy'
+    assert token.end == 1
+    assert token == SplitForm('했', 'VV+EP', 0, 1)
+    assert SplitForm.__module__ == 'kiwipiepy'
     assert pickle.loads(pickle.dumps(token)) == token
+
+    assert token.len == 1   # len은 end - start를 돌려주는 프로퍼티입니다.
+    assert token.tokens == []
+    assert repr(token) == "SplitForm(form='했', tag='VV+EP', start=0, end=1)"
+
+
+def test_split_form_tokens():
+    kiwi = Kiwi()
+    text = '했다 학생입니다'
+    parts = kiwi.split_into_forms(text)
+    tokens = kiwi.tokenize(text)
+
+    # 각 SplitForm의 tokens를 이어붙이면 원래 분석 결과와 같아야 합니다.
+    # Token은 값 비교를 지원하지 않으므로 속성으로 비교합니다.
+    def key(token):
+        return (token.form, token.tag, token.start, token.len)
+
+    assert [key(token) for part in parts for token in part.tokens] == [key(token) for token in tokens]
+    for part in parts:
+        assert part.tag == '+'.join(token.tag for token in part.tokens)
+        assert all(
+            part.start <= token.start and token.end <= part.end
+            for token in part.tokens
+        )
+
+    # tokens는 repr과 동등성 비교에서 제외됩니다.
+    assert parts[0].tokens
+    assert repr(parts[0]) == "SplitForm(form='했', tag='VV+EP', start=0, end=1)"
+    assert parts[0] == SplitForm('했', 'VV+EP', 0, 1)
 
 
 def test_split_by_spans_boundaries():
@@ -1199,21 +1228,21 @@ def test_split_by_spans_boundaries():
     assert _split_by_spans('A\u2800B', [
         token('A', 'SL', 0, 1),
         token('B', 'SL', 2, 3),
-    ]) == [SplitToken('A', 'SL', 0, 1), SplitToken('B', 'SL', 2, 1)]
+    ]) == [SplitForm('A', 'SL', 0, 1), SplitForm('B', 'SL', 2, 3)]
     assert _split_by_spans('A B', [token('A B', 'NNP', 0, 3)]) == [
-        SplitToken('A B', 'NNP', 0, 3),
+        SplitForm('A B', 'NNP', 0, 3),
     ]
     assert _split_by_spans('A B', [
         token('B', 'TB', 2, 3),
         token('A', 'TA', 0, 1),
-    ]) == [SplitToken('A', 'TA', 0, 1), SplitToken('B', 'TB', 2, 1)]
+    ]) == [SplitForm('A', 'TA', 0, 1), SplitForm('B', 'TB', 2, 3)]
 
     # 태그 순서는 위치 정렬 순서가 아니라 형태소 분석 결과 순서를 따릅니다.
     crossed = [
         token('B', 'EP', 1, 2),
         token('AB', 'VV', 0, 2),
     ]
-    assert _split_by_spans('AB', crossed) == [SplitToken('AB', 'EP+VV', 0, 2)]
+    assert _split_by_spans('AB', crossed) == [SplitForm('AB', 'EP+VV', 0, 2)]
 
     # 연쇄적으로 겹치는 구간은 합치되 맞닿기만 한 구간은 따로 둡니다.
     assert _split_by_spans('ABCDE', [
@@ -1222,25 +1251,25 @@ def test_split_by_spans_boundaries():
         token('D', 'NNG', 3, 4),
         token('E', 'JX', 4, 5),
     ]) == [
-        SplitToken('ABC', 'EP+VV', 0, 3),
-        SplitToken('D', 'NNG', 3, 1),
-        SplitToken('E', 'JX', 4, 1),
+        SplitForm('ABC', 'EP+VV', 0, 3),
+        SplitForm('D', 'NNG', 3, 4),
+        SplitForm('E', 'JX', 4, 5),
     ]
 
     # 길이가 0인 Token은 다음 표면형에, 다음 표면형이 없으면 이전에 결합합니다.
     assert _split_by_spans('A', [
         token('만', 'JX', 0, 0),
         token('A', 'NNG', 0, 1),
-    ]) == [SplitToken('A', 'JX+NNG', 0, 1)]
+    ]) == [SplitForm('A', 'JX+NNG', 0, 1)]
     assert _split_by_spans('AB', [
         token('A', 'NNG', 0, 1),
         token('이', 'VCP', 1, 1),
         token('B', 'EF', 1, 2),
-    ]) == [SplitToken('A', 'NNG', 0, 1), SplitToken('B', 'VCP+EF', 1, 1)]
+    ]) == [SplitForm('A', 'NNG', 0, 1), SplitForm('B', 'VCP+EF', 1, 2)]
     assert _split_by_spans('A', [
         token('A', 'NNG', 0, 1),
         token('만', 'JX', 1, 1),
-    ]) == [SplitToken('A', 'NNG+JX', 0, 1)]
+    ]) == [SplitForm('A', 'NNG+JX', 0, 1)]
     assert _split_by_spans('', [
         token('이', 'VCP', 0, 0),
     ]) == []


### PR DESCRIPTION
#227 에서 구현된 표면형 기반 분할 기능에는 `Kiwi.split`이라는 이름이 붙었는데 이미 Kiwi 클래스에는 문장 분할을 수행하는 `split_into_sents`라는 메소드가 존재함. 비슷한 이름을 가진 메소드가 두 개 존재하게 되어 혼동될 가능성이 있으므로 `split`이라는 이름을 조금 더 명확하게 `split_into_forms`로 수정하였다.
이와 동시에 메소드의 반환 타입도 `SplitToken`에서 `SplitForm`으로 변경. `split_into_sents`가 반환하는 `Sentence` 타입과 유사한 구조를 가지도록 하여 일관성을 확보하였다. 또한 `Sentence` 타입도 NamedTuple에서 data class로 통일.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `SplitForm` result type with form boundaries, length information, and associated morpheme tokens.
  - Renamed the splitting API to `split_into_forms`.
  - Improved sentence objects with immutable fields and compatibility accessors.

- **Bug Fixes**
  - Enhanced out-of-vocabulary error messages with character-frequency consistency details.

- **Compatibility**
  - Preserved legacy sentence access patterns with deprecation warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->